### PR TITLE
Taxid fixes

### DIFF
--- a/data/BGC0000299.json
+++ b/data/BGC0000299.json
@@ -134,7 +134,7 @@
         },
         "mibig_accession": "BGC0000299",
         "minimal": true,
-        "ncbi_tax_id": "1117317",
+        "ncbi_tax_id": "1279016",
         "organism_name": "Pseudoalteromonas piscicida JCM 20779",
         "publications": [
             "pubmed:25140825"

--- a/data/BGC0000314.json
+++ b/data/BGC0000314.json
@@ -52,7 +52,7 @@
         },
         "mibig_accession": "BGC0000314",
         "minimal": false,
-        "ncbi_tax_id": "1117317",
+        "ncbi_tax_id": "1279016",
         "nrp": {
             "cyclic": true,
             "nrps_genes": [

--- a/data/BGC0000319.json
+++ b/data/BGC0000319.json
@@ -72,7 +72,7 @@
         },
         "mibig_accession": "BGC0000319",
         "minimal": false,
-        "ncbi_tax_id": "443255",
+        "ncbi_tax_id": "1901",
         "nrp": {
             "cyclic": true,
             "nrps_genes": [

--- a/data/BGC0000373.json
+++ b/data/BGC0000373.json
@@ -44,7 +44,7 @@
         },
         "mibig_accession": "BGC0000373",
         "minimal": true,
-        "ncbi_tax_id": "443255",
+        "ncbi_tax_id": "1901",
         "organism_name": "Streptomyces clavuligerus ATCC 27064",
         "publications": [
             "pubmed:21041678"

--- a/data/BGC0000634.json
+++ b/data/BGC0000634.json
@@ -40,7 +40,7 @@
         },
         "mibig_accession": "BGC0000634",
         "minimal": true,
-        "ncbi_tax_id": "281067",
+        "ncbi_tax_id": "1113698",
         "organism_name": "Brevundimonas sp. SD212",
         "publications": [
             "pubmed:16085816"

--- a/data/BGC0000652.json
+++ b/data/BGC0000652.json
@@ -40,7 +40,7 @@
         },
         "mibig_accession": "BGC0000652",
         "minimal": true,
-        "ncbi_tax_id": "445602",
+        "ncbi_tax_id": "418855",
         "organism_name": "Streptomyces sp. CNQ525",
         "publications": [
             "pubmed:17392281"

--- a/data/BGC0000674.json
+++ b/data/BGC0000674.json
@@ -42,7 +42,7 @@
         },
         "mibig_accession": "BGC0000674",
         "minimal": true,
-        "ncbi_tax_id": "443255",
+        "ncbi_tax_id": "1901",
         "organism_name": "Streptomyces clavuligerus ATCC 27064",
         "publications": [
             "pubmed:21276937"

--- a/data/BGC0000675.json
+++ b/data/BGC0000675.json
@@ -42,7 +42,7 @@
         },
         "mibig_accession": "BGC0000675",
         "minimal": true,
-        "ncbi_tax_id": "443255",
+        "ncbi_tax_id": "1901",
         "organism_name": "Streptomyces clavuligerus ATCC 27064",
         "publications": [
             "pubmed:21276937"

--- a/data/BGC0000826.json
+++ b/data/BGC0000826.json
@@ -42,7 +42,7 @@
         },
         "mibig_accession": "BGC0000826",
         "minimal": true,
-        "ncbi_tax_id": "443255",
+        "ncbi_tax_id": "1901",
         "organism_name": "Streptomyces clavuligerus ATCC 27064",
         "publications": [
             "pubmed:20624727"

--- a/data/BGC0000841.json
+++ b/data/BGC0000841.json
@@ -206,7 +206,7 @@
         },
         "mibig_accession": "BGC0000841",
         "minimal": false,
-        "ncbi_tax_id": "443255",
+        "ncbi_tax_id": "1901",
         "organism_name": "Streptomyces clavuligerus ATCC 27064",
         "other": {
             "subclass": "Non-NRP beta-lactam"

--- a/data/BGC0000843.json
+++ b/data/BGC0000843.json
@@ -301,7 +301,7 @@
         },
         "mibig_accession": "BGC0000843",
         "minimal": false,
-        "ncbi_tax_id": "443255",
+        "ncbi_tax_id": "1901",
         "organism_name": "Streptomyces clavuligerus ATCC 27064",
         "other": {
             "subclass": "Non-NRP beta-lactam"

--- a/data/BGC0000845.json
+++ b/data/BGC0000845.json
@@ -353,7 +353,7 @@
         },
         "mibig_accession": "BGC0000845",
         "minimal": false,
-        "ncbi_tax_id": "443255",
+        "ncbi_tax_id": "1901",
         "organism_name": "Streptomyces clavuligerus ATCC 27064",
         "other": {
             "subclass": "Non-NRP beta-lactam"

--- a/data/BGC0001169.json
+++ b/data/BGC0001169.json
@@ -45,7 +45,7 @@
         },
         "mibig_accession": "BGC0001169",
         "minimal": false,
-        "ncbi_tax_id": "1109743",
+        "ncbi_tax_id": "1264596",
         "organism_name": "Streptomyces sp. SCSIO 03032",
         "polyketide": {
             "cyclic": false,

--- a/data/BGC0001172.json
+++ b/data/BGC0001172.json
@@ -78,7 +78,7 @@
         },
         "mibig_accession": "BGC0001172",
         "minimal": false,
-        "ncbi_tax_id": "1247109",
+        "ncbi_tax_id": "1288082",
         "nrp": {
             "cyclic": true
         },

--- a/data/BGC0001310.json
+++ b/data/BGC0001310.json
@@ -42,7 +42,7 @@
         },
         "mibig_accession": "BGC0001310",
         "minimal": true,
-        "ncbi_tax_id": "443255",
+        "ncbi_tax_id": "1901",
         "organism_name": "Streptomyces clavuligerus ATCC 27064",
         "publications": [
             "pubmed:26553209"

--- a/data/BGC0001349.json
+++ b/data/BGC0001349.json
@@ -92,7 +92,7 @@
         },
         "mibig_accession": "BGC0001349",
         "minimal": true,
-        "ncbi_tax_id": "1109743",
+        "ncbi_tax_id": "1264596",
         "organism_name": "Streptomyces sp. SCSIO 03032",
         "publications": [
             "pubmed:26194087"

--- a/data/BGC0001782.json
+++ b/data/BGC0001782.json
@@ -149,7 +149,7 @@
         },
         "mibig_accession": "BGC0001782",
         "minimal": true,
-        "ncbi_tax_id": "1109743",
+        "ncbi_tax_id": "1264596",
         "organism_name": "Streptomyces sp. SCSIO 03032",
         "publications": [
             "pubmed:28620687"


### PR DESCRIPTION
## Problem 
There are a number of taxids that are now outdated relative to NCBI. 

## Example

NCBI has changed the taxids for some of the genomes in Mibig. For example, [BGC0000319](https://mibig.secondarymetabolites.org/repository/BGC0000319/index.html#r1c1) has a producer of `Streptomyces clavuligerus` with a taxid of [443255](https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=443255) which is now redirected/redefined to taxid=1901

## Solutions

I've provided updated taxids for the issues I've noticed.