### PR TITLE
Fix broken DOI reference in BGC0001486

### DIFF
--- a/data/BGC0001486.json
+++ b/data/BGC0001486.json
@@ -39,7 +39,7 @@
         "ncbi_tax_id": "629265",
         "organism_name": "Pseudomonas syringae pv. maculicola str. ES4326",
         "publications": [
-            "doi:10.1101/33868"
+            "doi:10.1101/338681"
         ]
     }
 }


### PR DESCRIPTION
**Affected BGC**
[BGC0001486](https://mibig.secondarymetabolites.org/repository/BGC0001486/#r1c1)

**Describe the error**
The last digit of the DOI was stripped, this PR fixes it.