### PR TITLE
Gene identifier/annotation fixes

### DIFF
--- a/data/BGC0000029.json
+++ b/data/BGC0000029.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Removed gene names of 'No gene ID'"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -43,12 +52,10 @@
             "annotations": [
                 {
                     "id": "ACO94452.1",
-                    "name": "No gene ID",
                     "product": "putative secreted metal-binding protein"
                 },
                 {
                     "id": "ACO94453.1",
-                    "name": "No gene ID",
                     "product": "putative lipoprotein"
                 },
                 {
@@ -193,27 +200,22 @@
                 },
                 {
                     "id": "ACO94475.1",
-                    "name": "No gene ID",
                     "product": "PlsC-type phospholipid/glycerol acyltransferase"
                 },
                 {
                     "id": "ACO94476.1",
-                    "name": "No gene ID",
                     "product": "putative tripeptidylaminopeptidase"
                 },
                 {
                     "id": "ACO94477.1",
-                    "name": "No gene ID",
                     "product": "putative urease accessory protein"
                 },
                 {
                     "id": "ACO94478.1",
-                    "name": "No gene ID",
                     "product": "putative urease accessory protein"
                 },
                 {
                     "id": "ACO94479.1",
-                    "name": "No gene ID",
                     "product": "putative urease accessory protein"
                 }
             ]

--- a/data/BGC0000029.json
+++ b/data/BGC0000029.json
@@ -21,7 +21,8 @@
         },
         {
             "comments": [
-                "Removed gene names of 'No gene ID'"
+                "Removed gene names of 'No gene ID'",
+                "Removed duplicate gene name"
             ],
             "contributors": [
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
@@ -60,7 +61,6 @@
                 },
                 {
                     "id": "ACO94454.1",
-                    "name": "becH",
                     "product": "hypothetical protein"
                 },
                 {

--- a/data/BGC0000057.json
+++ b/data/BGC0000057.json
@@ -17,6 +17,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Removed gene names of 'No gene ID'"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -91,7 +100,6 @@
                 },
                 {
                     "id": "EAA59564.1",
-                    "name": "No gene ID",
                     "product": "NTF2-like superfamily protein, putative"
                 },
                 {

--- a/data/BGC0000083.json
+++ b/data/BGC0000083.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Fixed inconsistent gene labelling"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -176,13 +185,12 @@
             "synthases": [
                 {
                     "genes": [
-                        "ACY01400.1",
-                        "acy01397",
-                        "acy01402",
-                        "ACY01401.1",
+                        "ACY01397.1",
                         "ACY01398.1",
-                        "acy01403",
-                        "ACY01402.1"
+                        "ACY01400.1",
+                        "ACY01401.1",
+                        "ACY01402.1",
+                        "ACY01403.1"
                     ],
                     "modules": [
                         {
@@ -389,17 +397,17 @@
                     ],
                     "thioesterases": [
                         {
-                            "gene": "acy01397",
+                            "gene": "ACY01397.1",
                             "thioesterase_type": "Unknown"
                         },
                         {
-                            "gene": "acy01402",
+                            "gene": "ACY01402.1",
                             "thioesterase_type": "Unknown"
                         }
                     ],
                     "trans_at": {
                         "genes": [
-                            "acy01403"
+                            "ACY01403.1"
                         ]
                     }
                 }

--- a/data/BGC0000097.json
+++ b/data/BGC0000097.json
@@ -19,6 +19,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Removed gene names of 'No gene ID'"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -52,7 +61,6 @@
                         }
                     ],
                     "id": "ACO94480.1",
-                    "name": "No gene ID",
                     "product": "putative lipoprotein"
                 },
                 {
@@ -354,7 +362,6 @@
                         }
                     ],
                     "id": "ACO94503.1",
-                    "name": "No gene ID",
                     "product": "PlsC-type phospholipid/glycerol acyltransferase"
                 }
             ]

--- a/data/BGC0000097.json
+++ b/data/BGC0000097.json
@@ -22,7 +22,8 @@
         },
         {
             "comments": [
-                "Removed gene names of 'No gene ID'"
+                "Removed gene names of 'No gene ID'",
+                "Removed duplicate gene name"
             ],
             "contributors": [
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
@@ -73,7 +74,6 @@
                         }
                     ],
                     "id": "ACO94481.1",
-                    "name": "mlaH",
                     "product": "hypothetical protein"
                 },
                 {

--- a/data/BGC0000115.json
+++ b/data/BGC0000115.json
@@ -17,6 +17,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Removed gene names of 'No gene ID'"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -311,7 +320,6 @@
                         }
                     ],
                     "id": "AAF71781.1",
-                    "name": "No gene ID",
                     "product": "ORF4"
                 },
                 {
@@ -324,12 +332,10 @@
                         }
                     ],
                     "id": "AAF71782.1",
-                    "name": "No gene ID",
                     "product": "ORF3"
                 },
                 {
                     "id": "AAF71783.1",
-                    "name": "No gene ID",
                     "product": "ORF2"
                 }
             ]

--- a/data/BGC0000119.json
+++ b/data/BGC0000119.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Removed duplicate gene name"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -142,7 +151,6 @@
                 },
                 {
                     "id": "ACJ24856.1",
-                    "name": "ptmY",
                     "product": "putative ATP-dependent RNA helicase"
                 },
                 {

--- a/data/BGC0000122.json
+++ b/data/BGC0000122.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Remove leading/trailing whitespace in gene identifiers"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -101,7 +110,7 @@
                             ]
                         }
                     ],
-                    "id": "AHN85651 ",
+                    "id": "AHN85651",
                     "name": "phn2"
                 }
             ]

--- a/data/BGC0000144.json
+++ b/data/BGC0000144.json
@@ -20,7 +20,8 @@
         },
         {
             "comments": [
-                "Removed gene names of 'No gene ID'"
+                "Removed gene names of 'No gene ID'",
+                "Removed duplicate gene name"
             ],
             "contributors": [
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
@@ -83,7 +84,6 @@
                         }
                     ],
                     "id": "AEZ53944.1",
-                    "name": "slnA1",
                     "product": "putative 3-oxoacyl-(acyl-carrier-protein ) synthase III"
                 },
                 {

--- a/data/BGC0000144.json
+++ b/data/BGC0000144.json
@@ -17,6 +17,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Removed gene names of 'No gene ID'"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -62,7 +71,6 @@
                         }
                     ],
                     "id": "AEZ53943.1",
-                    "name": "No gene ID",
                     "product": "putative 3-hydroxybutyryl-CoA dehydrogenase"
                 },
                 {
@@ -262,7 +270,6 @@
                         }
                     ],
                     "id": "AEZ53971.1",
-                    "name": "No gene ID",
                     "product": "putative peptide carrier protein"
                 }
             ]

--- a/data/BGC0000147.json
+++ b/data/BGC0000147.json
@@ -21,10 +21,12 @@
         },
         {
             "comments": [
-                "Add PK subclass (issue #4)"
+                "Add PK subclass (issue #4)",
+                "Remove leading/trailing whitespace in gene identifiers"
             ],
             "contributors": [
-                "3UOU7PODQJXIM6BEPUHHRRA5"
+                "3UOU7PODQJXIM6BEPUHHRRA5",
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.1"
         }
@@ -80,7 +82,7 @@
                         }
                     ],
                     "id": "AAK19884.1",
-                    "name": "sorC "
+                    "name": "sorC"
                 },
                 {
                     "functions": [
@@ -92,7 +94,7 @@
                         }
                     ],
                     "id": "AAK19885.1",
-                    "name": "sorD ",
+                    "name": "sorD",
                     "product": "dehydrogenase"
                 },
                 {
@@ -105,7 +107,7 @@
                         }
                     ],
                     "id": "AAK19892.1",
-                    "name": "sorE ",
+                    "name": "sorE",
                     "product": "acyl-CoA dehydrogenase"
                 },
                 {
@@ -133,7 +135,7 @@
                         }
                     ],
                     "id": "AAK19893.1",
-                    "name": "sorR ",
+                    "name": "sorR",
                     "product": "reductase",
                     "tailoring": [
                         "Reduction"

--- a/data/BGC0000149.json
+++ b/data/BGC0000149.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Remove leading/trailing whitespace in gene identifiers"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -60,7 +69,7 @@
                         }
                     ],
                     "id": "CAL58679.1",
-                    "name": "spiB ",
+                    "name": "spiB",
                     "product": "O-methyltransferase",
                     "tailoring": [
                         "Methylation"
@@ -140,7 +149,7 @@
                         }
                     ],
                     "id": "CAL58685.1",
-                    "name": "spiH "
+                    "name": "spiH"
                 },
                 {
                     "functions": [
@@ -176,7 +185,7 @@
                         }
                     ],
                     "id": "CAL58688.1",
-                    "name": "spiK ",
+                    "name": "spiK",
                     "product": "O-methyltransferase",
                     "tailoring": [
                         "Methylation"
@@ -192,7 +201,7 @@
                         }
                     ],
                     "id": "CAL58689.1",
-                    "name": "spiL ",
+                    "name": "spiL",
                     "product": "cytochrome P450 dependent monooxygenase",
                     "tailoring": [
                         "Monooxygenation"

--- a/data/BGC0000153.json
+++ b/data/BGC0000153.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Fixed incorrect gene identifiers"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -96,7 +105,7 @@
                             ]
                         }
                     ],
-                    "id": "CAD19088.1",
+                    "id": "CAD19089.1",
                     "name": "stiE"
                 },
                 {
@@ -108,7 +117,7 @@
                             ]
                         }
                     ],
-                    "id": "CAD19089.1",
+                    "id": "CAD19090.1",
                     "name": "stiF"
                 },
                 {
@@ -120,7 +129,7 @@
                             ]
                         }
                     ],
-                    "id": "CAD19090.1",
+                    "id": "CAD19091.1",
                     "name": "stiG"
                 },
                 {
@@ -132,7 +141,7 @@
                             ]
                         }
                     ],
-                    "id": "CAD19091.1",
+                    "id": "CAD19092.1",
                     "name": "stiH"
                 },
                 {
@@ -144,7 +153,7 @@
                             ]
                         }
                     ],
-                    "id": "ctg1_orf00029",
+                    "id": "CAD19093.1",
                     "name": "stiJ"
                 },
                 {

--- a/data/BGC0000178.json
+++ b/data/BGC0000178.json
@@ -20,7 +20,8 @@
         },
         {
             "comments": [
-                "Fixed incorrect gene id in annotations"
+                "Fixed incorrect gene id in annotations",
+                "Remove leading/trailing whitespace in gene identifiers"
             ],
             "contributors": [
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
@@ -69,7 +70,7 @@
                         }
                     ],
                     "id": "AEC04349.1",
-                    "name": "elaC "
+                    "name": "elaC"
                 },
                 {
                     "functions": [

--- a/data/BGC0000178.json
+++ b/data/BGC0000178.json
@@ -17,6 +17,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Fixed incorrect gene id in annotations"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -179,7 +188,7 @@
                             ]
                         }
                     ],
-                    "id": "AEC04359.1",
+                    "id": "AEC04360.1",
                     "name": "elaN",
                     "tailoring": [
                         "Methylation"

--- a/data/BGC0000182.json
+++ b/data/BGC0000182.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Removed entry error in polyketide synthase gene list"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -111,7 +120,6 @@
             "synthases": [
                 {
                     "genes": [
-                        "1",
                         "AAM12911.1",
                         "AAM12909.2",
                         "AAM12913.2"

--- a/data/BGC0000197.json
+++ b/data/BGC0000197.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Removed gene names of 'No gene ID'"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -62,7 +71,6 @@
                         }
                     ],
                     "id": "ABL09959.1",
-                    "name": "No gene ID",
                     "product": "ketoacyl synthase"
                 },
                 {
@@ -75,7 +83,6 @@
                         }
                     ],
                     "id": "ABL09968.1",
-                    "name": "No gene ID",
                     "product": "L-rhamnosyltransferase",
                     "tailoring": [
                         "Glycosylation"

--- a/data/BGC0000198.json
+++ b/data/BGC0000198.json
@@ -17,6 +17,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Removed gene names of 'No gene ID'"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -49,7 +58,6 @@
                         }
                     ],
                     "id": "WP_029025939.1",
-                    "name": "No gene ID",
                     "product": "glucose-1-phosphate thymidylyltransferase"
                 },
                 {
@@ -62,7 +70,6 @@
                         }
                     ],
                     "id": "WP_029025941.1",
-                    "name": "No gene ID",
                     "product": "ABC transporter"
                 },
                 {
@@ -75,7 +82,6 @@
                         }
                     ],
                     "id": "WP_029025942.1",
-                    "name": "No gene ID",
                     "product": "ABC transporter permease"
                 },
                 {
@@ -88,7 +94,6 @@
                         }
                     ],
                     "id": "WP_029025951.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
@@ -101,7 +106,6 @@
                         }
                     ],
                     "id": "WP_029025952.1",
-                    "name": "No gene ID",
                     "product": "polyketide cyclase"
                 },
                 {
@@ -114,7 +118,6 @@
                         }
                     ],
                     "id": "WP_029025958.1",
-                    "name": "No gene ID",
                     "product": "beta-ACP synthase"
                 },
                 {
@@ -127,7 +130,6 @@
                         }
                     ],
                     "id": "WP_029025959.1",
-                    "name": "No gene ID",
                     "product": "beta-ketoacyl synthase"
                 },
                 {

--- a/data/BGC0000199.json
+++ b/data/BGC0000199.json
@@ -21,7 +21,8 @@
         },
         {
             "comments": [
-                "Removed gene names of 'No gene ID'"
+                "Removed gene names of 'No gene ID'",
+                "Removed duplicate gene name"
             ],
             "contributors": [
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
@@ -80,7 +81,6 @@
                         }
                     ],
                     "id": "AHA81971.1",
-                    "name": "arm1",
                     "product": "putative hydroxylase",
                     "tailoring": [
                         "Hydroxylation"

--- a/data/BGC0000199.json
+++ b/data/BGC0000199.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Removed gene names of 'No gene ID'"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -596,7 +605,6 @@
                         }
                     ],
                     "id": "AHA82006.1",
-                    "name": "No gene ID",
                     "product": "transposase"
                 }
             ]

--- a/data/BGC0000200.json
+++ b/data/BGC0000200.json
@@ -17,6 +17,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Removed gene names of 'No gene ID'"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -65,7 +74,6 @@
                         }
                     ],
                     "id": "AHX24686.1",
-                    "name": "No gene ID",
                     "product": "NAD-dependent epimerase/dehydratase",
                     "tailoring": [
                         "Epimerization"
@@ -81,7 +89,6 @@
                         }
                     ],
                     "id": "AHX24687.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
@@ -94,7 +101,6 @@
                         }
                     ],
                     "id": "AHX24688.1",
-                    "name": "No gene ID",
                     "product": "glycosyltransferase",
                     "tailoring": [
                         "Glycosylation"
@@ -110,7 +116,6 @@
                         }
                     ],
                     "id": "AHX24689.1",
-                    "name": "No gene ID",
                     "product": "short-chain dehydrogenase/reductase SDR"
                 },
                 {
@@ -123,7 +128,6 @@
                         }
                     ],
                     "id": "AHX24690.1",
-                    "name": "No gene ID",
                     "product": "amidotransferase",
                     "tailoring": [
                         "Unknown"
@@ -139,7 +143,6 @@
                         }
                     ],
                     "id": "AHX24691.1",
-                    "name": "No gene ID",
                     "product": "O-methyltransferase",
                     "tailoring": [
                         "Methylation"
@@ -155,7 +158,6 @@
                         }
                     ],
                     "id": "AHX24692.1",
-                    "name": "No gene ID",
                     "product": "ABC transporter"
                 },
                 {
@@ -168,7 +170,6 @@
                         }
                     ],
                     "id": "AHX24693.1",
-                    "name": "No gene ID",
                     "product": "ABC transporter ATP-binding protein"
                 },
                 {
@@ -181,7 +182,6 @@
                         }
                     ],
                     "id": "AHX24694.1",
-                    "name": "No gene ID",
                     "product": "glycosyltransferase",
                     "tailoring": [
                         "Glycosylation"
@@ -197,7 +197,6 @@
                         }
                     ],
                     "id": "AHX24695.1",
-                    "name": "No gene ID",
                     "product": "FAD-binding monooxygenase",
                     "tailoring": [
                         "Monooxygenation"
@@ -213,7 +212,6 @@
                         }
                     ],
                     "id": "AHX24696.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
@@ -226,7 +224,6 @@
                         }
                     ],
                     "id": "AHX24697.1",
-                    "name": "No gene ID",
                     "product": "O-methyltransferase",
                     "tailoring": [
                         "Methylation"
@@ -242,7 +239,6 @@
                         }
                     ],
                     "id": "AHX24698.1",
-                    "name": "No gene ID",
                     "product": "dehydrogenase",
                     "tailoring": [
                         "Dehydration"
@@ -258,7 +254,6 @@
                         }
                     ],
                     "id": "AHX24699.1",
-                    "name": "No gene ID",
                     "product": "cyclase"
                 },
                 {
@@ -271,7 +266,6 @@
                         }
                     ],
                     "id": "AHX24700.1",
-                    "name": "No gene ID",
                     "product": "cyclase"
                 },
                 {
@@ -284,7 +278,6 @@
                         }
                     ],
                     "id": "AHX24701.1",
-                    "name": "No gene ID",
                     "product": "beta-ketoacyl synthase alpha"
                 },
                 {
@@ -297,7 +290,6 @@
                         }
                     ],
                     "id": "AHX24702.1",
-                    "name": "No gene ID",
                     "product": "beta-ketoacyl synthase beta"
                 },
                 {
@@ -310,7 +302,6 @@
                         }
                     ],
                     "id": "AHX24703.1",
-                    "name": "No gene ID",
                     "product": "acyl carrier protein"
                 },
                 {
@@ -323,7 +314,6 @@
                         }
                     ],
                     "id": "AHX24704.1",
-                    "name": "No gene ID",
                     "product": "cyclase"
                 },
                 {
@@ -336,7 +326,6 @@
                         }
                     ],
                     "id": "AHX24705.1",
-                    "name": "No gene ID",
                     "product": "monooxygenase",
                     "tailoring": [
                         "Monooxygenation"
@@ -352,7 +341,6 @@
                         }
                     ],
                     "id": "AHX24706.1",
-                    "name": "No gene ID",
                     "product": "3-oxoacyl-ACP reductase",
                     "tailoring": [
                         "Reduction"
@@ -368,7 +356,6 @@
                         }
                     ],
                     "id": "AHX24707.1",
-                    "name": "No gene ID",
                     "product": "monooxygenase",
                     "tailoring": [
                         "Monooxygenation"
@@ -384,7 +371,6 @@
                         }
                     ],
                     "id": "AHX24708.1",
-                    "name": "No gene ID",
                     "product": "monooxygenase",
                     "tailoring": [
                         "Monooxygenation"
@@ -400,7 +386,6 @@
                         }
                     ],
                     "id": "AHX24709.1",
-                    "name": "No gene ID",
                     "product": "NDP-4-ketoreductase",
                     "tailoring": [
                         "Reduction"
@@ -416,7 +401,6 @@
                         }
                     ],
                     "id": "AHX24710.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
@@ -429,7 +413,6 @@
                         }
                     ],
                     "id": "AHX24711.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
@@ -442,7 +425,6 @@
                         }
                     ],
                     "id": "AHX24712.1",
-                    "name": "No gene ID",
                     "product": "3-oxoacyl-ACP reductase",
                     "tailoring": [
                         "Reduction"
@@ -458,7 +440,6 @@
                         }
                     ],
                     "id": "AHX24713.1",
-                    "name": "No gene ID",
                     "product": "putative peptide transporter"
                 },
                 {
@@ -471,7 +452,6 @@
                         }
                     ],
                     "id": "AHX24714.1",
-                    "name": "No gene ID",
                     "product": "CurD-like protein"
                 },
                 {
@@ -484,7 +464,6 @@
                         }
                     ],
                     "id": "AHX24715.1",
-                    "name": "No gene ID",
                     "product": "FAD-binding monooxygenase",
                     "tailoring": [
                         "Monooxygenation"
@@ -500,7 +479,6 @@
                         }
                     ],
                     "id": "AHX24716.1",
-                    "name": "No gene ID",
                     "product": "LuxR family transcriptional regulator"
                 },
                 {
@@ -513,12 +491,10 @@
                         }
                     ],
                     "id": "AHX24717.1",
-                    "name": "No gene ID",
                     "product": "two-component system histidine kinase"
                 },
                 {
                     "id": "AHX24718.1",
-                    "name": "No gene ID",
                     "product": "F420-dependent reductase",
                     "tailoring": [
                         "Reduction"
@@ -526,7 +502,6 @@
                 },
                 {
                     "id": "AHX24719.1",
-                    "name": "No gene ID",
                     "product": "putative methyltransferase",
                     "tailoring": [
                         "Methylation"
@@ -534,7 +509,6 @@
                 },
                 {
                     "id": "AHX24720.1",
-                    "name": "No gene ID",
                     "product": "biotin carboxyl carrier protein"
                 }
             ]

--- a/data/BGC0000210.json
+++ b/data/BGC0000210.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Removed duplicate gene annotation"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -149,23 +158,6 @@
                     "name": "cmmGIII",
                     "tailoring": [
                         "Glycosylation"
-                    ]
-                },
-                {
-                    "functions": [
-                        {
-                            "category": "Tailoring",
-                            "evidence": [
-                                "Knock-out",
-                                "Activity assay",
-                                "Sequence-based prediction"
-                            ]
-                        }
-                    ],
-                    "id": "CAE17546.1",
-                    "name": "cmmA",
-                    "tailoring": [
-                        "Acylation"
                     ]
                 },
                 {

--- a/data/BGC0000223.json
+++ b/data/BGC0000223.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Removed gene names of 'No gene ID'"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -94,7 +103,6 @@
                         }
                     ],
                     "id": "AEE65458.1",
-                    "name": "No gene ID",
                     "product": "beta-lactamase domain protein"
                 },
                 {
@@ -107,7 +115,6 @@
                         }
                     ],
                     "id": "AEE65459.1",
-                    "name": "No gene ID",
                     "product": "bata-lactamase"
                 },
                 {
@@ -120,7 +127,6 @@
                         }
                     ],
                     "id": "AEE65460.1",
-                    "name": "No gene ID",
                     "product": "transcriptional regulater"
                 },
                 {
@@ -133,7 +139,6 @@
                         }
                     ],
                     "id": "AEE65461.1",
-                    "name": "No gene ID",
                     "product": "carboxyl transferase",
                     "tailoring": [
                         "Carboxylation"
@@ -149,7 +154,6 @@
                         }
                     ],
                     "id": "AEE65462.1",
-                    "name": "No gene ID",
                     "product": "oxygenase",
                     "tailoring": [
                         "Oxidation"
@@ -165,7 +169,6 @@
                         }
                     ],
                     "id": "AEE65463.1",
-                    "name": "No gene ID",
                     "product": "Oxygenase reductase-like protein",
                     "tailoring": [
                         "Oxidation"
@@ -181,7 +184,6 @@
                         }
                     ],
                     "id": "AEE65464.1",
-                    "name": "No gene ID",
                     "product": "aromatase"
                 },
                 {
@@ -194,7 +196,6 @@
                         }
                     ],
                     "id": "AEE65465.1",
-                    "name": "No gene ID",
                     "product": "ketoreductase",
                     "tailoring": [
                         "Reduction"
@@ -210,7 +211,6 @@
                         }
                     ],
                     "id": "AEE65466.1",
-                    "name": "No gene ID",
                     "product": "acyl carrier protein"
                 },
                 {
@@ -223,7 +223,6 @@
                         }
                     ],
                     "id": "AEE65467.1",
-                    "name": "No gene ID",
                     "product": "chain length determinant"
                 },
                 {
@@ -236,7 +235,6 @@
                         }
                     ],
                     "id": "AEE65468.1",
-                    "name": "No gene ID",
                     "product": "ketoacyl synthase"
                 },
                 {
@@ -249,7 +247,6 @@
                         }
                     ],
                     "id": "AEE65469.1",
-                    "name": "No gene ID",
                     "product": "putative polyketide cyclase"
                 },
                 {
@@ -262,7 +259,6 @@
                         }
                     ],
                     "id": "AEE65470.1",
-                    "name": "No gene ID",
                     "product": "carboxylase, alpha subunit",
                     "tailoring": [
                         "Carboxylation"
@@ -278,7 +274,6 @@
                         }
                     ],
                     "id": "AEE65471.1",
-                    "name": "No gene ID",
                     "product": "two component regulater"
                 },
                 {
@@ -291,7 +286,6 @@
                         }
                     ],
                     "id": "AEE65472.1",
-                    "name": "No gene ID",
                     "product": "oxidase-related FMN-binding protein"
                 },
                 {
@@ -304,7 +298,6 @@
                         }
                     ],
                     "id": "AEE65473.1",
-                    "name": "No gene ID",
                     "product": "oxygenase-like protein",
                     "tailoring": [
                         "Oxidation"
@@ -320,7 +313,6 @@
                         }
                     ],
                     "id": "AEE65474.1",
-                    "name": "No gene ID",
                     "product": "oxidase-like protein",
                     "tailoring": [
                         "Oxidation"
@@ -336,7 +328,6 @@
                         }
                     ],
                     "id": "AEE65475.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
@@ -349,7 +340,6 @@
                         }
                     ],
                     "id": "AEE65476.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
@@ -362,7 +352,6 @@
                         }
                     ],
                     "id": "AEE65477.1",
-                    "name": "No gene ID",
                     "product": "NAD-dependent epimerase/dehydratase",
                     "tailoring": [
                         "Epimerization"
@@ -378,7 +367,6 @@
                         }
                     ],
                     "id": "AEE65478.1",
-                    "name": "No gene ID",
                     "product": "putative oxygenase",
                     "tailoring": [
                         "Oxidation"
@@ -394,7 +382,6 @@
                         }
                     ],
                     "id": "AEE65479.1",
-                    "name": "No gene ID",
                     "product": "oxidoreductase",
                     "tailoring": [
                         "Unknown"
@@ -410,7 +397,6 @@
                         }
                     ],
                     "id": "AEE65480.1",
-                    "name": "No gene ID",
                     "product": "putative O-methyltransferase",
                     "tailoring": [
                         "Methylation"
@@ -426,7 +412,6 @@
                         }
                     ],
                     "id": "AEE65481.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
@@ -439,7 +424,6 @@
                         }
                     ],
                     "id": "AEE65522.1",
-                    "name": "No gene ID",
                     "product": "alcohol dehydrogenase",
                     "tailoring": [
                         "Oxidation"
@@ -455,7 +439,6 @@
                         }
                     ],
                     "id": "AEE65482.1",
-                    "name": "No gene ID",
                     "product": "3-oxoacyl-(acyl carrier protein) synthase III"
                 },
                 {
@@ -468,7 +451,6 @@
                         }
                     ],
                     "id": "AEE65483.1",
-                    "name": "No gene ID",
                     "product": "short-chain dehydrogenase/reductase SDR",
                     "tailoring": [
                         "Reduction"
@@ -484,7 +466,6 @@
                         }
                     ],
                     "id": "AEE65484.1",
-                    "name": "No gene ID",
                     "product": "monooxygenase",
                     "tailoring": [
                         "Monooxygenation"
@@ -500,7 +481,6 @@
                         }
                     ],
                     "id": "AEE65485.1",
-                    "name": "No gene ID",
                     "product": "streptomycin biosynthesis operon regulator"
                 },
                 {
@@ -513,7 +493,6 @@
                         }
                     ],
                     "id": "AEE65486.1",
-                    "name": "No gene ID",
                     "product": "Nitric-oxide synthase"
                 },
                 {
@@ -526,7 +505,6 @@
                         }
                     ],
                     "id": "AEE65487.1",
-                    "name": "No gene ID",
                     "product": "amidohydrolase-like protein",
                     "tailoring": [
                         "Hydrolysis"
@@ -542,7 +520,6 @@
                         }
                     ],
                     "id": "AEE65488.1",
-                    "name": "No gene ID",
                     "product": "GCN5-related N-acetyltransferase",
                     "tailoring": [
                         "Acetylation"
@@ -558,7 +535,6 @@
                         }
                     ],
                     "id": "AEE65489.1",
-                    "name": "No gene ID",
                     "product": "adenylosuccinate lyase",
                     "tailoring": [
                         "Hydrolysis"
@@ -574,7 +550,6 @@
                         }
                     ],
                     "id": "AEE65490.1",
-                    "name": "No gene ID",
                     "product": "amidase",
                     "tailoring": [
                         "Amination"
@@ -590,7 +565,6 @@
                         }
                     ],
                     "id": "AEE65491.1",
-                    "name": "No gene ID",
                     "product": "glutamine synthetase"
                 },
                 {
@@ -603,7 +577,6 @@
                         }
                     ],
                     "id": "AEE65492.1",
-                    "name": "No gene ID",
                     "product": "putative ferredoxin"
                 },
                 {
@@ -616,7 +589,6 @@
                         }
                     ],
                     "id": "AEE65493.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
@@ -629,7 +601,6 @@
                         }
                     ],
                     "id": "AEE65494.1",
-                    "name": "No gene ID",
                     "product": "response regulator"
                 },
                 {
@@ -642,7 +613,6 @@
                         }
                     ],
                     "id": "AEE65495.1",
-                    "name": "No gene ID",
                     "product": "Hypothetical protein"
                 },
                 {
@@ -655,7 +625,6 @@
                         }
                     ],
                     "id": "AEE65496.1",
-                    "name": "No gene ID",
                     "product": "PAS/PAC sensor signal transduction histidine kinase"
                 },
                 {
@@ -668,7 +637,6 @@
                         }
                     ],
                     "id": "AEE65497.1",
-                    "name": "No gene ID",
                     "product": "ShdA"
                 },
                 {
@@ -681,7 +649,6 @@
                         }
                     ],
                     "id": "AEE65498.1",
-                    "name": "No gene ID",
                     "product": "antitoxin component"
                 },
                 {
@@ -694,7 +661,6 @@
                         }
                     ],
                     "id": "AEE65499.1",
-                    "name": "No gene ID",
                     "product": "putative regulatory protein"
                 },
                 {
@@ -707,7 +673,6 @@
                         }
                     ],
                     "id": "AEE65500.1",
-                    "name": "No gene ID",
                     "product": "putative regulatory protein"
                 },
                 {
@@ -720,7 +685,6 @@
                         }
                     ],
                     "id": "AEE65501.1",
-                    "name": "No gene ID",
                     "product": "conserved hypothetical protein"
                 },
                 {
@@ -733,7 +697,6 @@
                         }
                     ],
                     "id": "AEE65502.1",
-                    "name": "No gene ID",
                     "product": "geranylgeranyl reductase",
                     "tailoring": [
                         "Reduction"
@@ -749,7 +712,6 @@
                         }
                     ],
                     "id": "AEE65503.1",
-                    "name": "No gene ID",
                     "product": "galactoside O-acetyltransferase",
                     "tailoring": [
                         "Acetylation"
@@ -765,7 +727,6 @@
                         }
                     ],
                     "id": "AEE65504.1",
-                    "name": "No gene ID",
                     "product": "transcriptional regulator, TetR family"
                 },
                 {
@@ -778,7 +739,6 @@
                         }
                     ],
                     "id": "AEE65505.1",
-                    "name": "No gene ID",
                     "product": "putative DeoR-type transcriptional regulator"
                 },
                 {
@@ -791,7 +751,6 @@
                         }
                     ],
                     "id": "AEE65506.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
@@ -804,7 +763,6 @@
                         }
                     ],
                     "id": "AEE65507.1",
-                    "name": "No gene ID",
                     "product": "AGR369Wp"
                 },
                 {
@@ -817,7 +775,6 @@
                         }
                     ],
                     "id": "AEE65508.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
@@ -830,7 +787,6 @@
                         }
                     ],
                     "id": "AEE65509.1",
-                    "name": "No gene ID",
                     "product": "intracellular protease"
                 },
                 {
@@ -843,7 +799,6 @@
                         }
                     ],
                     "id": "AEE65510.1",
-                    "name": "No gene ID",
                     "product": "integral membrane protein"
                 },
                 {
@@ -856,7 +811,6 @@
                         }
                     ],
                     "id": "AEE65511.1",
-                    "name": "No gene ID",
                     "product": "NUDIX hydrolase"
                 },
                 {
@@ -869,7 +823,6 @@
                         }
                     ],
                     "id": "AEE65512.1",
-                    "name": "No gene ID",
                     "product": "Ku protein"
                 },
                 {
@@ -882,7 +835,6 @@
                         }
                     ],
                     "id": "AEE65513.1",
-                    "name": "No gene ID",
                     "product": "DNA polymerase LigD ligase region"
                 },
                 {
@@ -895,7 +847,6 @@
                         }
                     ],
                     "id": "AEE65514.1",
-                    "name": "No gene ID",
                     "product": "DNA polymerase LigD, polymerase domain protein"
                 },
                 {
@@ -908,7 +859,6 @@
                         }
                     ],
                     "id": "AEE65515.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
@@ -921,7 +871,6 @@
                         }
                     ],
                     "id": "AEE65516.1",
-                    "name": "No gene ID",
                     "product": "transcriptional regulator, PadR-like family"
                 },
                 {
@@ -934,7 +883,6 @@
                         }
                     ],
                     "id": "AEE65517.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
@@ -947,22 +895,18 @@
                         }
                     ],
                     "id": "AEE65518.1",
-                    "name": "No gene ID",
                     "product": "helicase domain protein"
                 },
                 {
                     "id": "AEE65519.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
                     "id": "AEE65520.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
                     "id": "AEE65521.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 }
             ]

--- a/data/BGC0000229.json
+++ b/data/BGC0000229.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected polyketide synthase gene entries"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -524,7 +533,9 @@
             "synthases": [
                 {
                     "genes": [
-                        "ago50610.1,ago50611.1,ago50612.1",
+                        "AGO50610.1",
+                        "AGO50611.1",
+                        "AGO50612.1",
                         "AGO50614.1",
                         "AGO50613.1"
                     ],

--- a/data/BGC0000230.json
+++ b/data/BGC0000230.json
@@ -17,6 +17,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Removed duplicate gene annotations"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -98,19 +107,6 @@
                 {
                     "functions": [
                         {
-                            "category": "Regulation",
-                            "evidence": [
-                                "Sequence-based prediction"
-                            ]
-                        }
-                    ],
-                    "id": "AAM33680.1",
-                    "name": "grhR2",
-                    "product": "putative transcriptional activator"
-                },
-                {
-                    "functions": [
-                        {
                             "category": "Scaffold biosynthesis",
                             "evidence": [
                                 "Sequence-based prediction"
@@ -163,64 +159,6 @@
                 {
                     "functions": [
                         {
-                            "category": "Precursor biosynthesis",
-                            "evidence": [
-                                "Sequence-based prediction"
-                            ]
-                        }
-                    ],
-                    "id": "AAM33659.1",
-                    "name": "grhG",
-                    "product": "putative transcarboxylase component of acyl-CoA carboxylase"
-                },
-                {
-                    "functions": [
-                        {
-                            "category": "Precursor biosynthesis",
-                            "evidence": [
-                                "Sequence-based prediction"
-                            ]
-                        }
-                    ],
-                    "id": "AAM33659.1",
-                    "name": "grhG",
-                    "product": "putative transcarboxylase component of acyl-CoA carboxylase"
-                },
-                {
-                    "functions": [
-                        {
-                            "category": "Tailoring",
-                            "evidence": [
-                                "Sequence-based prediction"
-                            ]
-                        }
-                    ],
-                    "id": "AAM33667.1",
-                    "name": "grhO1",
-                    "product": "putative FAD-binding oxidoreductase",
-                    "tailoring": [
-                        "Monooxygenation"
-                    ]
-                },
-                {
-                    "functions": [
-                        {
-                            "category": "Tailoring",
-                            "evidence": [
-                                "Sequence-based prediction"
-                            ]
-                        }
-                    ],
-                    "id": "AAM33667.1",
-                    "name": "grhO1",
-                    "product": "putative FAD-binding oxidoreductase",
-                    "tailoring": [
-                        "Monooxygenation"
-                    ]
-                },
-                {
-                    "functions": [
-                        {
                             "category": "Tailoring",
                             "evidence": [
                                 "Sequence-based prediction"
@@ -246,58 +184,6 @@
                     "id": "AAM33671.1",
                     "name": "grhO4",
                     "product": "putative ferredoxin"
-                },
-                {
-                    "functions": [
-                        {
-                            "category": "Other enzymatic",
-                            "evidence": [
-                                "Sequence-based prediction"
-                            ]
-                        }
-                    ],
-                    "id": "AAM33671.1",
-                    "name": "grhO4",
-                    "product": "putative ferredoxin"
-                },
-                {
-                    "functions": [
-                        {
-                            "category": "Other enzymatic",
-                            "evidence": [
-                                "Sequence-based prediction"
-                            ]
-                        }
-                    ],
-                    "id": "AAM33671.1",
-                    "name": "grhO4",
-                    "product": "putative ferredoxin"
-                },
-                {
-                    "functions": [
-                        {
-                            "category": "Regulation",
-                            "evidence": [
-                                "Sequence-based prediction"
-                            ]
-                        }
-                    ],
-                    "id": "AAM33681.1",
-                    "name": "grhR3",
-                    "product": "putative transcriptional repressor"
-                },
-                {
-                    "functions": [
-                        {
-                            "category": "Regulation",
-                            "evidence": [
-                                "Sequence-based prediction"
-                            ]
-                        }
-                    ],
-                    "id": "AAM33681.1",
-                    "name": "grhR3",
-                    "product": "putative transcriptional repressor"
                 },
                 {
                     "functions": [
@@ -324,86 +210,6 @@
                     "id": "AAM33663.1",
                     "name": "grhK",
                     "product": "putative efflux protein"
-                },
-                {
-                    "functions": [
-                        {
-                            "category": "Tailoring",
-                            "evidence": [
-                                "Sequence-based prediction"
-                            ]
-                        }
-                    ],
-                    "id": "AAM33664.1",
-                    "name": "grhL",
-                    "product": "putative methyltransferase",
-                    "tailoring": [
-                        "Methylation"
-                    ]
-                },
-                {
-                    "functions": [
-                        {
-                            "category": "Tailoring",
-                            "evidence": [
-                                "Sequence-based prediction"
-                            ]
-                        }
-                    ],
-                    "id": "AAM33664.1",
-                    "name": "grhL",
-                    "product": "putative methyltransferase",
-                    "tailoring": [
-                        "Methylation"
-                    ]
-                },
-                {
-                    "functions": [
-                        {
-                            "category": "Tailoring",
-                            "evidence": [
-                                "Sequence-based prediction"
-                            ]
-                        }
-                    ],
-                    "id": "AAM33664.1",
-                    "name": "grhL",
-                    "product": "putative methyltransferase",
-                    "tailoring": [
-                        "Methylation"
-                    ]
-                },
-                {
-                    "functions": [
-                        {
-                            "category": "Tailoring",
-                            "evidence": [
-                                "Sequence-based prediction"
-                            ]
-                        }
-                    ],
-                    "id": "AAM33664.1",
-                    "name": "grhL",
-                    "product": "putative methyltransferase",
-                    "tailoring": [
-                        "Methylation"
-                    ]
-                },
-                {
-                    "functions": [
-                        {
-                            "category": "Tailoring",
-                            "evidence": [
-                                "Sequence-based prediction"
-                            ]
-                        }
-                    ],
-                    "id": "AAM33664.1",
-                    "name": "grhL",
-                    "product": "putative methyltransferase",
-                    "tailoring": [
-                        "Methylation"
-                    ]
                 },
                 {
                     "functions": [

--- a/data/BGC0000239.json
+++ b/data/BGC0000239.json
@@ -21,10 +21,12 @@
         },
         {
             "comments": [
-                "Remove duplicated citations"
+                "Remove duplicated citations",
+                "Remove leading/trailing whitespace in gene identifiers"
             ],
             "contributors": [
-                "3UOU7PODQJXIM6BEPUHHRRA5"
+                "3UOU7PODQJXIM6BEPUHHRRA5",
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.1"
         }
@@ -110,7 +112,7 @@
                         }
                     ],
                     "id": "AAD13552.1",
-                    "name": "LanV ",
+                    "name": "LanV",
                     "product": "bifunctional reductase + aromatase",
                     "tailoring": [
                         "Reduction"

--- a/data/BGC0000241.json
+++ b/data/BGC0000241.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Removed gene names of 'No gene ID'"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -102,7 +111,6 @@
                         }
                     ],
                     "id": "ABP54623.1",
-                    "name": "No gene ID",
                     "product": "drug resistance transporter, EmrB/QacA subfamily"
                 },
                 {
@@ -115,7 +123,6 @@
                         }
                     ],
                     "id": "ABP54624.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
@@ -128,7 +135,6 @@
                         }
                     ],
                     "id": "ABP54625.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
@@ -141,7 +147,6 @@
                         }
                     ],
                     "id": "ABP54626.1",
-                    "name": "No gene ID",
                     "product": "ABC transporter related"
                 },
                 {
@@ -154,7 +159,6 @@
                         }
                     ],
                     "id": "ABP54627.1",
-                    "name": "No gene ID",
                     "product": "Glyoxalase/bleomycin resistance protein/dioxygenase"
                 },
                 {
@@ -167,7 +171,6 @@
                         }
                     ],
                     "id": "ABP54628.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
@@ -180,7 +183,6 @@
                         }
                     ],
                     "id": "ABP54629.1",
-                    "name": "No gene ID",
                     "product": "transcriptional activator domain"
                 },
                 {
@@ -193,7 +195,6 @@
                         }
                     ],
                     "id": "ABP54630.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
@@ -206,7 +207,6 @@
                         }
                     ],
                     "id": "ABP54631.1",
-                    "name": "No gene ID",
                     "product": "transcriptional regulator, AraC family"
                 },
                 {
@@ -219,7 +219,6 @@
                         }
                     ],
                     "id": "ABP54632.1",
-                    "name": "No gene ID",
                     "product": "NDP-hexose 2,3-dehydratase"
                 },
                 {
@@ -232,7 +231,6 @@
                         }
                     ],
                     "id": "ABP54633.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
@@ -245,7 +243,6 @@
                         }
                     ],
                     "id": "ABP54634.1",
-                    "name": "No gene ID",
                     "product": "Carboxymuconolactone decarboxylase"
                 },
                 {
@@ -258,7 +255,6 @@
                         }
                     ],
                     "id": "ABP54635.1",
-                    "name": "No gene ID",
                     "product": "peptidase C26"
                 },
                 {
@@ -271,7 +267,6 @@
                         }
                     ],
                     "id": "ABP54636.1",
-                    "name": "No gene ID",
                     "product": "monooxygenase, FAD-binding",
                     "tailoring": [
                         "Hydroxylation"
@@ -287,7 +282,6 @@
                         }
                     ],
                     "id": "ABP54637.1",
-                    "name": "No gene ID",
                     "product": "protoporphyrinogen oxidase"
                 },
                 {
@@ -300,7 +294,6 @@
                         }
                     ],
                     "id": "ABP54638.1",
-                    "name": "No gene ID",
                     "product": "ParB domain protein nuclease"
                 },
                 {
@@ -313,7 +306,6 @@
                         }
                     ],
                     "id": "ABP54639.1",
-                    "name": "No gene ID",
                     "product": "monooxygenase, FAD-binding",
                     "tailoring": [
                         "Oxidation"
@@ -329,7 +321,6 @@
                         }
                     ],
                     "id": "ABP54640.1",
-                    "name": "No gene ID",
                     "product": "monooxygenase, FAD-binding",
                     "tailoring": [
                         "Oxidation"
@@ -345,7 +336,6 @@
                         }
                     ],
                     "id": "ABP54641.1",
-                    "name": "No gene ID",
                     "product": "short-chain dehydrogenase/reductase SDR"
                 },
                 {
@@ -358,7 +348,6 @@
                         }
                     ],
                     "id": "ABP54642.1",
-                    "name": "No gene ID",
                     "product": "NmrA family protein",
                     "tailoring": [
                         "Unknown"
@@ -374,7 +363,6 @@
                         }
                     ],
                     "id": "ABP54643.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
@@ -387,7 +375,6 @@
                         }
                     ],
                     "id": "ABP54644.1",
-                    "name": "No gene ID",
                     "product": "Polyketide synthesis cyclase"
                 },
                 {
@@ -400,7 +387,6 @@
                         }
                     ],
                     "id": "ABP54645.1",
-                    "name": "No gene ID",
                     "product": "short-chain dehydrogenase/reductase SDR"
                 },
                 {
@@ -413,7 +399,6 @@
                         }
                     ],
                     "id": "ABP54646.1",
-                    "name": "No gene ID",
                     "product": "hydroxyneurosporene-O-methyltransferase"
                 },
                 {
@@ -426,7 +411,6 @@
                         }
                     ],
                     "id": "ABP54647.1",
-                    "name": "No gene ID",
                     "product": "monooxygenase, FAD-binding",
                     "tailoring": [
                         "Reduction"
@@ -442,7 +426,6 @@
                         }
                     ],
                     "id": "ABP54648.1",
-                    "name": "No gene ID",
                     "product": "cyclase/dehydrase"
                 },
                 {
@@ -455,7 +438,6 @@
                         }
                     ],
                     "id": "ABP54649.1",
-                    "name": "No gene ID",
                     "product": "monooxygenase, FAD-binding"
                 },
                 {
@@ -468,7 +450,6 @@
                         }
                     ],
                     "id": "ABP54650.1",
-                    "name": "No gene ID",
                     "product": "monooxygenase, FAD-binding"
                 },
                 {
@@ -481,7 +462,6 @@
                         }
                     ],
                     "id": "ABP54651.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
@@ -494,7 +474,6 @@
                         }
                     ],
                     "id": "ABP54652.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
@@ -507,7 +486,6 @@
                         }
                     ],
                     "id": "ABP54653.1",
-                    "name": "No gene ID",
                     "product": "4Fe-4S ferredoxin, iron-sulfur binding domain protein"
                 },
                 {
@@ -520,7 +498,6 @@
                         }
                     ],
                     "id": "ABP54654.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
@@ -533,7 +510,6 @@
                         }
                     ],
                     "id": "ABP54655.1",
-                    "name": "No gene ID",
                     "product": "L-glutamine synthetase"
                 },
                 {
@@ -546,7 +522,6 @@
                         }
                     ],
                     "id": "ABP54656.1",
-                    "name": "No gene ID",
                     "product": "Amidase"
                 },
                 {
@@ -559,7 +534,6 @@
                         }
                     ],
                     "id": "ABP54657.1",
-                    "name": "No gene ID",
                     "product": "Adenylosuccinate lyase"
                 },
                 {
@@ -572,7 +546,6 @@
                         }
                     ],
                     "id": "ABP54658.1",
-                    "name": "No gene ID",
                     "product": "GCN5-related N-acetyltransferase"
                 },
                 {
@@ -585,7 +558,6 @@
                         }
                     ],
                     "id": "ABP54659.1",
-                    "name": "No gene ID",
                     "product": "ABC transporter related"
                 },
                 {
@@ -598,7 +570,6 @@
                         }
                     ],
                     "id": "ABP54660.1",
-                    "name": "No gene ID",
                     "product": "Rieske (2Fe-2S) domain protein"
                 },
                 {
@@ -611,7 +582,6 @@
                         }
                     ],
                     "id": "ABP54661.1",
-                    "name": "No gene ID",
                     "product": "Glyoxalase/bleomycin resistance protein/dioxygenase"
                 },
                 {
@@ -624,7 +594,6 @@
                         }
                     ],
                     "id": "ABP54662.1",
-                    "name": "No gene ID",
                     "product": "Glyoxalase/bleomycin resistance protein/dioxygenase"
                 },
                 {
@@ -637,7 +606,6 @@
                         }
                     ],
                     "id": "ABP54663.1",
-                    "name": "No gene ID",
                     "product": "TAP domain protein"
                 },
                 {
@@ -650,7 +618,6 @@
                         }
                     ],
                     "id": "ABP54664.1",
-                    "name": "No gene ID",
                     "product": "protein of unknown function DUF1205"
                 },
                 {
@@ -663,7 +630,6 @@
                         }
                     ],
                     "id": "ABP54665.1",
-                    "name": "No gene ID",
                     "product": "O-methyltransferase, family 2"
                 },
                 {
@@ -676,7 +642,6 @@
                         }
                     ],
                     "id": "ABP54666.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
@@ -689,7 +654,6 @@
                         }
                     ],
                     "id": "ABP54667.1",
-                    "name": "No gene ID",
                     "product": "NAD-dependent epimerase/dehydratase"
                 },
                 {
@@ -702,7 +666,6 @@
                         }
                     ],
                     "id": "ABP54668.1",
-                    "name": "No gene ID",
                     "product": "dTDP-4-dehydrorhamnose 3,5-epimerase"
                 },
                 {
@@ -715,7 +678,6 @@
                         }
                     ],
                     "id": "ABP54669.1",
-                    "name": "No gene ID",
                     "product": "oxidoreductase domain protein"
                 },
                 {
@@ -728,7 +690,6 @@
                         }
                     ],
                     "id": "ABP54670.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
@@ -741,7 +702,6 @@
                         }
                     ],
                     "id": "ABP54671.1",
-                    "name": "No gene ID",
                     "product": "protein of unknown function DUF1205"
                 },
                 {
@@ -754,7 +714,6 @@
                         }
                     ],
                     "id": "ABP54672.1",
-                    "name": "No gene ID",
                     "product": "DegT/DnrJ/EryC1/StrS aminotransferase"
                 },
                 {
@@ -767,7 +726,6 @@
                         }
                     ],
                     "id": "ABP54673.1",
-                    "name": "No gene ID",
                     "product": "dTDP-glucose 4,6-dehydratase"
                 },
                 {
@@ -780,7 +738,6 @@
                         }
                     ],
                     "id": "ABP54674.1",
-                    "name": "No gene ID",
                     "product": "beta-ketoacyl synthase"
                 },
                 {
@@ -793,7 +750,6 @@
                         }
                     ],
                     "id": "ABP54675.1",
-                    "name": "No gene ID",
                     "product": "beta-ketoacyl synthase"
                 },
                 {
@@ -806,7 +762,6 @@
                         }
                     ],
                     "id": "ABP54676.1",
-                    "name": "No gene ID",
                     "product": "phosphopantetheine-binding"
                 },
                 {
@@ -819,7 +774,6 @@
                         }
                     ],
                     "id": "ABP54677.1",
-                    "name": "No gene ID",
                     "product": "acyl transferase domain protein"
                 },
                 {
@@ -832,7 +786,6 @@
                         }
                     ],
                     "id": "ABP54678.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
@@ -845,7 +798,6 @@
                         }
                     ],
                     "id": "ABP54679.1",
-                    "name": "No gene ID",
                     "product": "transcriptional regulator, AraC family"
                 },
                 {
@@ -858,7 +810,6 @@
                         }
                     ],
                     "id": "ABP54680.1",
-                    "name": "No gene ID",
                     "product": "Glucose-1-phosphate thymidylyltransferase"
                 }
             ]

--- a/data/BGC0000269.json
+++ b/data/BGC0000269.json
@@ -17,6 +17,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Removed gene names of 'No gene ID'"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -61,17 +70,14 @@
             "annotations": [
                 {
                     "id": "ADE34480.1",
-                    "name": "No gene ID",
                     "product": "cysteine desulferase"
                 },
                 {
                     "id": "ADE34481.1",
-                    "name": "No gene ID",
                     "product": "SUF system FeS assembly protein"
                 },
                 {
                     "id": "ADE34482.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {

--- a/data/BGC0000274.json
+++ b/data/BGC0000274.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Removed gene names of 'No gene ID'"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -62,7 +71,6 @@
                         }
                     ],
                     "id": "AFY23032.1",
-                    "name": "No gene ID",
                     "product": "TamA"
                 },
                 {
@@ -75,7 +83,6 @@
                         }
                     ],
                     "id": "AFY23031.1",
-                    "name": "No gene ID",
                     "product": "30S ribosomal protein S1"
                 },
                 {
@@ -88,7 +95,6 @@
                         }
                     ],
                     "id": "AFY23033.1",
-                    "name": "No gene ID",
                     "product": "TamB",
                     "tailoring": [
                         "Oxidation"
@@ -104,7 +110,6 @@
                         }
                     ],
                     "id": "AFY23034.1",
-                    "name": "No gene ID",
                     "product": "TamC",
                     "tailoring": [
                         "Reduction"
@@ -120,7 +125,6 @@
                         }
                     ],
                     "id": "AFY23035.1",
-                    "name": "No gene ID",
                     "product": "TamD"
                 },
                 {
@@ -133,7 +137,6 @@
                         }
                     ],
                     "id": "AFY23036.1",
-                    "name": "No gene ID",
                     "product": "TamE",
                     "tailoring": [
                         "Reduction"
@@ -149,7 +152,6 @@
                         }
                     ],
                     "id": "AFY23037.1",
-                    "name": "No gene ID",
                     "product": "TamF",
                     "tailoring": [
                         "Oxidation"
@@ -165,7 +167,6 @@
                         }
                     ],
                     "id": "AFY23038.1",
-                    "name": "No gene ID",
                     "product": "TamG"
                 },
                 {
@@ -178,7 +179,6 @@
                         }
                     ],
                     "id": "AFY23039.1",
-                    "name": "No gene ID",
                     "product": "TamH"
                 },
                 {
@@ -191,7 +191,6 @@
                         }
                     ],
                     "id": "AFY23040.1",
-                    "name": "No gene ID",
                     "product": "TamI"
                 },
                 {
@@ -204,7 +203,6 @@
                         }
                     ],
                     "id": "AFY23041.1",
-                    "name": "No gene ID",
                     "product": "TamJ"
                 },
                 {
@@ -217,7 +215,6 @@
                         }
                     ],
                     "id": "AFY23042.1",
-                    "name": "No gene ID",
                     "product": "TamK"
                 },
                 {
@@ -230,7 +227,6 @@
                         }
                     ],
                     "id": "AFY23043.1",
-                    "name": "No gene ID",
                     "product": "TamL"
                 },
                 {
@@ -243,7 +239,6 @@
                         }
                     ],
                     "id": "AFY23044.1",
-                    "name": "No gene ID",
                     "product": "TamM"
                 },
                 {
@@ -256,7 +251,6 @@
                         }
                     ],
                     "id": "AFY23045.1",
-                    "name": "No gene ID",
                     "product": "TamN",
                     "tailoring": [
                         "Reduction"
@@ -272,7 +266,6 @@
                         }
                     ],
                     "id": "AFY23046.1",
-                    "name": "No gene ID",
                     "product": "TamO",
                     "tailoring": [
                         "Methylation"
@@ -288,7 +281,6 @@
                         }
                     ],
                     "id": "AFY23047.1",
-                    "name": "No gene ID",
                     "product": "TamP"
                 }
             ]

--- a/data/BGC0000289.json
+++ b/data/BGC0000289.json
@@ -21,7 +21,8 @@
         {
             "comments": [
                 "Corrected NRP module activity",
-                "Removed gene names of 'No gene ID'"
+                "Removed gene names of 'No gene ID'",
+                "Removed duplicate gene name"
             ],
             "contributors": [
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
@@ -130,7 +131,6 @@
                         }
                     ],
                     "id": "CAD91195.1",
-                    "name": "dbv1",
                     "product": "hypothetical protein"
                 },
                 {

--- a/data/BGC0000289.json
+++ b/data/BGC0000289.json
@@ -20,7 +20,8 @@
         },
         {
             "comments": [
-                "Corrected NRP module activity"
+                "Corrected NRP module activity",
+                "Removed gene names of 'No gene ID'"
             ],
             "contributors": [
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
@@ -69,7 +70,6 @@
                         }
                     ],
                     "id": "CAD91190.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
@@ -82,7 +82,6 @@
                         }
                     ],
                     "id": "CAD91191.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
@@ -95,7 +94,6 @@
                         }
                     ],
                     "id": "CAD91192.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
@@ -108,7 +106,6 @@
                         }
                     ],
                     "id": "CAD91193.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
@@ -121,7 +118,6 @@
                         }
                     ],
                     "id": "CAD91194.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {

--- a/data/BGC0000337.json
+++ b/data/BGC0000337.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Removed duplicate gene annotation"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -38,6 +47,7 @@
         "genes": {
             "annotations": [
                 {
+                    "comments": "Biosynthesis of the first NRP dtx B.",
                     "functions": [
                         {
                             "category": "Scaffold biosynthesis",
@@ -48,9 +58,10 @@
                     ],
                     "id": "MAA_10043",
                     "name": "DtxS1",
-                    "product": "Biosynthesis of the first NRP dtx B."
+                    "product": "non-ribosomal peptide synthetase"
                 },
                 {
+                    "comments": "metabolite hydroxylation, desaturation, oxidation, and/or epoxidation",
                     "functions": [
                         {
                             "category": "Tailoring",
@@ -61,12 +72,13 @@
                     ],
                     "id": "MAA_10044",
                     "name": "DtxS2",
-                    "product": "metabolite hydroxylation, desaturation, oxidation, and/or epoxidation",
+                    "product": "benzoate 4-monooxygenase cytochrome P450",
                     "tailoring": [
                         "Oxidation"
                     ]
                 },
                 {
+                    "comments": "Conversion of alpha-ketoisocaproic acid into alpha-hydroxyisocaproic acid",
                     "functions": [
                         {
                             "category": "Precursor biosynthesis",
@@ -77,9 +89,10 @@
                     ],
                     "id": "MAA_10045",
                     "name": "DtxS3",
-                    "product": "Conversion of alpha-ketoisocaproic acid into alpha-hydroxyisocaproic acid"
+                    "product": "aldo-keto reductase"
                 },
                 {
+                    "comments": "Decarboxylation of aspartic acid into beta-Alanine",
                     "functions": [
                         {
                             "category": "Precursor biosynthesis",
@@ -90,7 +103,7 @@
                     ],
                     "id": "MAA_10046",
                     "name": "DtxS4",
-                    "product": "Decarboxylation of aspartic acid into beta-Alanine"
+                    "product": "glutamate decarboxylase"
                 },
                 {
                     "comments": "smCOG: SMCOG1055:pyruvate_oxidase/decarboxylase (Score: 262.7; E-value: 1.2e-79);",
@@ -145,26 +158,6 @@
                 {
                     "id": "MAA_10042",
                     "product": "phytanoyl-CoA dioxygenase family protein"
-                },
-                {
-                    "comments": "smCOG: SMCOG1002:AMP-dependent_synthetase_and_ligase (Score: 285.7; E-value: 9.6e-87);",
-                    "id": "MAA_10043",
-                    "product": "non-ribosomal peptide synthetase"
-                },
-                {
-                    "comments": "smCOG: SMCOG1034:cytochrome_P450 (Score: 330.2; E-value: 3.5e-100);",
-                    "id": "MAA_10044",
-                    "product": "benzoate 4-monooxygenase cytochrome P450"
-                },
-                {
-                    "comments": "smCOG: SMCOG1039:aldo/keto_reductase_family_oxidoreductase (Score: 312.2; E-value: 5.7e-95);",
-                    "id": "MAA_10045",
-                    "product": "aldo-keto reductase"
-                },
-                {
-                    "comments": "smCOG: SMCOG1180:Decarboxylase,_pyridoxal-dependent (Score: 285.4; E-value: 1.2e-86);",
-                    "id": "MAA_10046",
-                    "product": "glutamate decarboxylase, putative"
                 },
                 {
                     "id": "MAA_10047",

--- a/data/BGC0000374.json
+++ b/data/BGC0000374.json
@@ -20,7 +20,8 @@
         },
         {
             "comments": [
-                "Corrected NRP module activity"
+                "Corrected NRP module activity",
+                "Removed gene names of 'No gene ID'"
             ],
             "contributors": [
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
@@ -294,7 +295,6 @@
                         }
                     ],
                     "id": "AEH41781.1",
-                    "name": "No gene ID",
                     "product": "HrmA"
                 },
                 {
@@ -307,7 +307,6 @@
                         }
                     ],
                     "id": "AEH41782.1",
-                    "name": "No gene ID",
                     "product": "HrmB"
                 },
                 {
@@ -320,7 +319,6 @@
                         }
                     ],
                     "id": "AEH41802.1",
-                    "name": "No gene ID",
                     "product": "HrmC"
                 },
                 {
@@ -333,7 +331,6 @@
                         }
                     ],
                     "id": "AEH41801.1",
-                    "name": "No gene ID",
                     "product": "HrmD"
                 },
                 {
@@ -346,7 +343,6 @@
                         }
                     ],
                     "id": "AEH41783.1",
-                    "name": "No gene ID",
                     "product": "HrmE"
                 },
                 {
@@ -359,7 +355,6 @@
                         }
                     ],
                     "id": "AEH41784.1",
-                    "name": "No gene ID",
                     "product": "HrmF"
                 },
                 {
@@ -372,7 +367,6 @@
                         }
                     ],
                     "id": "AEH41785.1",
-                    "name": "No gene ID",
                     "product": "HrmG"
                 },
                 {
@@ -385,7 +379,6 @@
                         }
                     ],
                     "id": "AEH41786.1",
-                    "name": "No gene ID",
                     "product": "HrmH"
                 },
                 {
@@ -398,7 +391,6 @@
                         }
                     ],
                     "id": "AEH41787.1",
-                    "name": "No gene ID",
                     "product": "HrmI"
                 },
                 {
@@ -411,7 +403,6 @@
                         }
                     ],
                     "id": "AEH41788.1",
-                    "name": "No gene ID",
                     "product": "HrmJ"
                 },
                 {
@@ -424,7 +415,6 @@
                         }
                     ],
                     "id": "AEH41789.1",
-                    "name": "No gene ID",
                     "product": "HrmK"
                 },
                 {
@@ -437,7 +427,6 @@
                         }
                     ],
                     "id": "AEH41790.1",
-                    "name": "No gene ID",
                     "product": "HrmL"
                 },
                 {
@@ -450,7 +439,6 @@
                         }
                     ],
                     "id": "AEH41791.1",
-                    "name": "No gene ID",
                     "product": "HrmM"
                 },
                 {
@@ -463,7 +451,6 @@
                         }
                     ],
                     "id": "AEH41792.1",
-                    "name": "No gene ID",
                     "product": "HrmN"
                 },
                 {
@@ -476,7 +463,6 @@
                         }
                     ],
                     "id": "AEH41793.1",
-                    "name": "No gene ID",
                     "product": "HrmO"
                 },
                 {
@@ -489,7 +475,6 @@
                         }
                     ],
                     "id": "AEH41794.1",
-                    "name": "No gene ID",
                     "product": "HrmP"
                 },
                 {
@@ -502,7 +487,6 @@
                         }
                     ],
                     "id": "ACE80255.1",
-                    "name": "No gene ID",
                     "product": "HrmQ"
                 },
                 {
@@ -515,7 +499,6 @@
                         }
                     ],
                     "id": "AEH41800.1",
-                    "name": "No gene ID",
                     "product": "HrmR"
                 },
                 {
@@ -528,7 +511,6 @@
                         }
                     ],
                     "id": "AEH41795.1",
-                    "name": "No gene ID",
                     "product": "HrmS"
                 },
                 {
@@ -541,7 +523,6 @@
                         }
                     ],
                     "id": "AEH41796.1",
-                    "name": "No gene ID",
                     "product": "HrmT"
                 },
                 {
@@ -554,7 +535,6 @@
                         }
                     ],
                     "id": "AEH41797.1",
-                    "name": "No gene ID",
                     "product": "HrmU"
                 },
                 {
@@ -567,7 +547,6 @@
                         }
                     ],
                     "id": "AEH41798.1",
-                    "name": "No gene ID",
                     "product": "HrmV"
                 },
                 {
@@ -580,7 +559,6 @@
                         }
                     ],
                     "id": "AEH41799.1",
-                    "name": "No gene ID",
                     "product": "HrmW"
                 }
             ]

--- a/data/BGC0000380.json
+++ b/data/BGC0000380.json
@@ -20,7 +20,8 @@
         },
         {
             "comments": [
-                "Corrected NRP module activity"
+                "Corrected NRP module activity",
+                "Fixed incorrect gene identifiers and names"
             ],
             "contributors": [
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
@@ -256,7 +257,7 @@
                             ]
                         }
                     ],
-                    "id": "ADZ24996.1",
+                    "id": "ADZ24997.1",
                     "name": "leuC"
                 },
                 {
@@ -269,7 +270,7 @@
                         }
                     ],
                     "id": "ADZ24998.1",
-                    "name": "leuD ",
+                    "name": "leuD",
                     "product": "polyketide synthase"
                 },
                 {

--- a/data/BGC0000380.json
+++ b/data/BGC0000380.json
@@ -21,7 +21,8 @@
         {
             "comments": [
                 "Corrected NRP module activity",
-                "Fixed incorrect gene identifiers and names"
+                "Fixed incorrect gene identifiers and names",
+                "Remove leading/trailing whitespace in gene identifiers"
             ],
             "contributors": [
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
@@ -105,7 +106,7 @@
                 },
                 {
                     "id": "ADZ25003.1",
-                    "name": "leu14 ",
+                    "name": "leu14",
                     "product": "O-methyltransferase",
                     "tailoring": [
                         "Methylation"
@@ -150,7 +151,7 @@
                         }
                     ],
                     "id": "ADZ24988.1",
-                    "name": "leu4 ",
+                    "name": "leu4",
                     "product": "acyltransferase",
                     "tailoring": [
                         "Unknown"
@@ -179,7 +180,7 @@
                         }
                     ],
                     "id": "ADZ24990.1",
-                    "name": "leu6 ",
+                    "name": "leu6",
                     "product": "prolyl-ACP dehydrogenase"
                 },
                 {

--- a/data/BGC0000429.json
+++ b/data/BGC0000429.json
@@ -23,7 +23,8 @@
         {
             "comments": [
                 "Manually updates compound information for skyllamycin A & B (Structure from Pubchem isn't correct)",
-                "Corrected NRP module activity"
+                "Corrected NRP module activity",
+                "Removed gene names of 'No gene ID'"
             ],
             "contributors": [
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
@@ -166,7 +167,6 @@
                         }
                     ],
                     "id": "AEA30252.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
@@ -707,7 +707,6 @@
                         }
                     ],
                     "id": "AEA30292.1",
-                    "name": "No gene ID",
                     "product": "putative DNA polymerase III"
                 }
             ]

--- a/data/BGC0000429.json
+++ b/data/BGC0000429.json
@@ -24,7 +24,8 @@
             "comments": [
                 "Manually updates compound information for skyllamycin A & B (Structure from Pubchem isn't correct)",
                 "Corrected NRP module activity",
-                "Removed gene names of 'No gene ID'"
+                "Removed gene names of 'No gene ID'",
+                "Removed duplicate gene names"
             ],
             "contributors": [
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
@@ -89,7 +90,6 @@
                         }
                     ],
                     "id": "AEA30246.1",
-                    "name": "sky4",
                     "product": "putative cytosine/adenosine deaminase"
                 },
                 {
@@ -141,7 +141,6 @@
                         }
                     ],
                     "id": "AEA30250.1",
-                    "name": "sky8",
                     "product": "hypothetical protein"
                 },
                 {
@@ -179,7 +178,6 @@
                         }
                     ],
                     "id": "AEA30253.1",
-                    "name": "sky11",
                     "product": "putative integrin-like protein"
                 },
                 {
@@ -205,7 +203,6 @@
                         }
                     ],
                     "id": "AEA30255.1",
-                    "name": "sky13",
                     "product": "putative isoprenyl diphosphate synthase"
                 },
                 {
@@ -497,7 +494,6 @@
                         }
                     ],
                     "id": "AEA30277.1",
-                    "name": "sky35",
                     "product": "hypothetical protein"
                 },
                 {

--- a/data/BGC0000433.json
+++ b/data/BGC0000433.json
@@ -21,7 +21,8 @@
         },
         {
             "comments": [
-                "Corrected NRP module activity"
+                "Corrected NRP module activity",
+                "Remove leading/trailing whitespace in gene identifiers"
             ],
             "contributors": [
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
@@ -124,7 +125,7 @@
                             ]
                         }
                     ],
-                    "id": "YP001420002 ",
+                    "id": "YP001420002",
                     "name": "ycxc",
                     "product": "transporter"
                 },

--- a/data/BGC0000472.json
+++ b/data/BGC0000472.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Removed gene names of 'No gene ID'"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -99,7 +108,6 @@
                         }
                     ],
                     "id": "ADA00389.1",
-                    "name": "no gene ID",
                     "product": "transposase"
                 },
                 {
@@ -128,7 +136,6 @@
                         }
                     ],
                     "id": "ADA00391.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
@@ -141,7 +148,6 @@
                         }
                     ],
                     "id": "ADA00392.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
@@ -154,7 +160,6 @@
                         }
                     ],
                     "id": "ADA00393.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
@@ -167,7 +172,6 @@
                         }
                     ],
                     "id": "ADA00394.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {

--- a/data/BGC0000579.json
+++ b/data/BGC0000579.json
@@ -17,6 +17,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Removed duplicate gene annotation"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -55,15 +64,6 @@
                     ],
                     "id": "SSEG_09672",
                     "product": "lactamase"
-                },
-                {
-                    "id": "SSEG_05172",
-                    "product": "hypothetical protein"
-                },
-                {
-                    "comments": "smCOG: SMCOG1177:asparagine_synthase_(glutamine-hydrolyzing) (Score: 98.8; E-value: 5.1e-30);",
-                    "id": "SSEG_09672",
-                    "product": "predicted protein"
                 }
             ],
             "extra_genes": [

--- a/data/BGC0000597.json
+++ b/data/BGC0000597.json
@@ -17,6 +17,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Removed duplicate gene annotation"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -53,16 +62,6 @@
                             ]
                         }
                     ],
-                    "id": "SSTG_01180",
-                    "product": "acyl-CoA synthetase"
-                },
-                {
-                    "comments": "smCOG: SMCOG1246:monooxygenase_FAD-binding (Score: 422.5; E-value: 3.2e-128);",
-                    "id": "SSTG_01176",
-                    "product": "hypothetical protein"
-                },
-                {
-                    "comments": "smCOG: SMCOG1002:AMP-dependent_synthetase_and_ligase (Score: 293.7; E-value: 3.5e-89);",
                     "id": "SSTG_01180",
                     "product": "acyl-CoA synthetase"
                 },

--- a/data/BGC0000598.json
+++ b/data/BGC0000598.json
@@ -20,10 +20,12 @@
         },
         {
             "comments": [
-                "Corrected organism information"
+                "Corrected organism information",
+                "Remove leading/trailing whitespace in gene identifiers"
             ],
             "contributors": [
-                "OFPWNRO3FNTFB6S6A7RD76XT"
+                "OFPWNRO3FNTFB6S6A7RD76XT",
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.1"
         }
@@ -123,7 +125,7 @@
                             ]
                         }
                     ],
-                    "id": " AFS60635 ",
+                    "id": "AFS60635",
                     "name": "poyJ",
                     "product": "putative transporter-hydrolase fusion protein"
                 },
@@ -195,7 +197,7 @@
                             ]
                         }
                     ],
-                    "id": "AFS60641 ",
+                    "id": "AFS60641",
                     "name": "poyE",
                     "tailoring": [
                         "Methylation"
@@ -239,7 +241,7 @@
                             ]
                         }
                     ],
-                    "id": "AFS60644 ",
+                    "id": "AFS60644",
                     "name": "poyH"
                 },
                 {

--- a/data/BGC0000631.json
+++ b/data/BGC0000631.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected erroneous gene annotations"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -50,8 +59,8 @@
                             ]
                         }
                     ],
-                    "id": "Bcin12g06370.1",
-                    "name": "gene_Bcin12g06370",
+                    "id": "ATZ56105.1",
+                    "name": "Bcbot4",
                     "product": "Bcbot4",
                     "tailoring": [
                         "Monooxygenation"
@@ -66,8 +75,8 @@
                             ]
                         }
                     ],
-                    "id": "Bcin12g06380.1",
-                    "name": "gene_Bcin12g06380",
+                    "id": "ATZ56106.1",
+                    "name": "Bcbot1",
                     "product": "Bcbot1",
                     "tailoring": [
                         "Monooxygenation"
@@ -82,8 +91,8 @@
                             ]
                         }
                     ],
-                    "id": "Bcin12g06390.1",
-                    "name": "gene_Bcin12g06390",
+                    "id": "ATZ56107.1",
+                    "name": "Bcbot2",
                     "product": "Bcbot2"
                 },
                 {
@@ -95,8 +104,8 @@
                             ]
                         }
                     ],
-                    "id": "Bcin12g06400.1",
-                    "name": "gene_Bcin12g06400",
+                    "id": "ATZ56108.1",
+                    "name": "Bcbot3",
                     "product": "Bcbot3",
                     "tailoring": [
                         "Monooxygenation"
@@ -111,8 +120,8 @@
                             ]
                         }
                     ],
-                    "id": "Bcin12g06410.1",
-                    "name": "gene_Bcin12g06410",
+                    "id": "ATZ56109.1",
+                    "name": "Bcbot5",
                     "product": "Bcbot5",
                     "tailoring": [
                         "Acetylation"
@@ -127,8 +136,8 @@
                             ]
                         }
                     ],
-                    "id": "Bcin12g06420.1",
-                    "name": "gene_Bcin12g06420",
+                    "id": "ATZ56111.1",
+                    "name": "Bcbot6",
                     "product": "Bcbot6"
                 },
                 {
@@ -140,226 +149,12 @@
                             ]
                         }
                     ],
-                    "id": "Bcin12g06430.1",
-                    "name": "gene_Bcin12g06430",
+                    "id": "ATZ56112.1",
+                    "name": "Bcbot7",
                     "product": "Bcbot7",
                     "tailoring": [
                         "Dehydration"
                     ]
-                },
-                {
-                    "comments": "smCOG: SMCOG1034:cytochrome_P450 (Score: 302.9; E-value: 7.1e-92);",
-                    "id": "Bcin12g06370.1"
-                },
-                {
-                    "comments": "smCOG: SMCOG1034:cytochrome_P450 (Score: 332.0; E-value: 1e-100);",
-                    "id": "Bcin12g06380.1"
-                },
-                {
-                    "comments": "smCOG: SMCOG1052:Terpene_synthase/cyclase_metal-binding_domain_pro tein (Score: 237.7; E-value: 3.5e-72);",
-                    "id": "Bcin12g06390.1"
-                },
-                {
-                    "comments": "smCOG: SMCOG1034:cytochrome_P450 (Score: 251.8; E-value: 2.2e-76);",
-                    "id": "Bcin12g06400.1"
-                },
-                {
-                    "comments": "smCOG: SMCOG1001:short-chain_dehydrogenase/reductase_SDR (Score: 127.5; E-value: 1e-38);",
-                    "id": "Bcin12g06430.1"
-                }
-            ],
-            "extra_genes": [
-                {
-                    "id": "Bcin12g06370.1",
-                    "location": {
-                        "exons": [
-                            {
-                                "end": 2219693,
-                                "start": 2219559
-                            },
-                            {
-                                "end": 2219485,
-                                "start": 2219393
-                            },
-                            {
-                                "end": 2219325,
-                                "start": 2219256
-                            },
-                            {
-                                "end": 2219195,
-                                "start": 2218799
-                            },
-                            {
-                                "end": 2218735,
-                                "start": 2218569
-                            },
-                            {
-                                "end": 2218512,
-                                "start": 2218403
-                            },
-                            {
-                                "end": 2218333,
-                                "start": 2218070
-                            },
-                            {
-                                "end": 2218001,
-                                "start": 2217841
-                            },
-                            {
-                                "end": 2217770,
-                                "start": 2217594
-                            }
-                        ],
-                        "strand": -1
-                    }
-                },
-                {
-                    "id": "Bcin12g06380.1",
-                    "location": {
-                        "exons": [
-                            {
-                                "end": 2223086,
-                                "start": 2222840
-                            },
-                            {
-                                "end": 2222748,
-                                "start": 2222690
-                            },
-                            {
-                                "end": 2222635,
-                                "start": 2221572
-                            },
-                            {
-                                "end": 2221491,
-                                "start": 2221333
-                            }
-                        ],
-                        "strand": -1
-                    }
-                },
-                {
-                    "id": "Bcin12g06390.1",
-                    "location": {
-                        "exons": [
-                            {
-                                "end": 2223854,
-                                "start": 2223574
-                            },
-                            {
-                                "end": 2224091,
-                                "start": 2223966
-                            },
-                            {
-                                "end": 2224172,
-                                "start": 2224154
-                            },
-                            {
-                                "end": 2224406,
-                                "start": 2224241
-                            },
-                            {
-                                "end": 2224795,
-                                "start": 2224545
-                            },
-                            {
-                                "end": 2225123,
-                                "start": 2224870
-                            },
-                            {
-                                "end": 2225294,
-                                "start": 2225199
-                            }
-                        ],
-                        "strand": 1
-                    }
-                },
-                {
-                    "id": "Bcin12g06400.1",
-                    "location": {
-                        "exons": [
-                            {
-                                "end": 2228545,
-                                "start": 2228143
-                            },
-                            {
-                                "end": 2228047,
-                                "start": 2227918
-                            },
-                            {
-                                "end": 2227849,
-                                "start": 2227802
-                            },
-                            {
-                                "end": 2227731,
-                                "start": 2227511
-                            },
-                            {
-                                "end": 2227438,
-                                "start": 2227374
-                            },
-                            {
-                                "end": 2227303,
-                                "start": 2226800
-                            },
-                            {
-                                "end": 2226708,
-                                "start": 2226548
-                            },
-                            {
-                                "end": 2226465,
-                                "start": 2226301
-                            }
-                        ],
-                        "strand": -1
-                    }
-                },
-                {
-                    "id": "Bcin12g06410.1",
-                    "location": {
-                        "exons": [
-                            {
-                                "end": 2229900,
-                                "start": 2229580
-                            },
-                            {
-                                "end": 2231314,
-                                "start": 2229998
-                            }
-                        ],
-                        "strand": 1
-                    }
-                },
-                {
-                    "id": "Bcin12g06420.1",
-                    "location": {
-                        "exons": [
-                            {
-                                "end": 2243290,
-                                "start": 2241836
-                            }
-                        ],
-                        "strand": 1
-                    }
-                },
-                {
-                    "id": "Bcin12g06430.1",
-                    "location": {
-                        "exons": [
-                            {
-                                "end": 2244208,
-                                "start": 2244157
-                            },
-                            {
-                                "end": 2244822,
-                                "start": 2244294
-                            },
-                            {
-                                "end": 2245275,
-                                "start": 2244907
-                            }
-                        ],
-                        "strand": 1
-                    }
                 }
             ]
         },

--- a/data/BGC0000646.json
+++ b/data/BGC0000646.json
@@ -17,6 +17,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Removed gene names of 'No gene ID'"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -52,7 +61,6 @@
                         }
                     ],
                     "id": "ACI04496.1",
-                    "name": "No gene ID",
                     "product": "CrtY"
                 },
                 {
@@ -65,7 +73,6 @@
                         }
                     ],
                     "id": "ACI04497.1",
-                    "name": "No gene ID",
                     "product": "CrtE"
                 },
                 {
@@ -78,7 +85,6 @@
                         }
                     ],
                     "id": "ACI04498.1",
-                    "name": "No gene ID",
                     "product": "CrtI",
                     "tailoring": [
                         "Reduction"
@@ -94,7 +100,6 @@
                         }
                     ],
                     "id": "ACI04499.1",
-                    "name": "No gene ID",
                     "product": "CrtB"
                 },
                 {
@@ -107,7 +112,6 @@
                         }
                     ],
                     "id": "ACI04500.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
@@ -120,7 +124,6 @@
                         }
                     ],
                     "id": "ACI04501.1",
-                    "name": "No gene ID",
                     "product": "CrtX"
                 }
             ]

--- a/data/BGC0000661.json
+++ b/data/BGC0000661.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Removed gene names of 'No gene ID'"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -51,7 +60,6 @@
                         }
                     ],
                     "id": "ACC81293.1",
-                    "name": "No gene ID",
                     "product": "Geosmin synthase"
                 },
                 {
@@ -64,7 +72,6 @@
                         }
                     ],
                     "id": "ACC81292.1",
-                    "name": "No gene ID",
                     "product": "cyclic nucleotide-binding protein"
                 },
                 {
@@ -77,7 +84,6 @@
                         }
                     ],
                     "id": "ACC81291.1",
-                    "name": "No gene ID",
                     "product": "cyclic nucleotide-binding protein"
                 }
             ]

--- a/data/BGC0000845.json
+++ b/data/BGC0000845.json
@@ -17,6 +17,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Removed gene names of 'No gene ID'"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -192,7 +201,6 @@
                         }
                     ],
                     "id": "EDY47132.1",
-                    "name": "No gene ID",
                     "product": "beta-lactamase"
                 },
                 {
@@ -205,7 +213,6 @@
                         }
                     ],
                     "id": "EDY47133.1",
-                    "name": "No gene ID",
                     "product": "efflux protein"
                 },
                 {
@@ -218,7 +225,6 @@
                         }
                     ],
                     "id": "EDY47134.1",
-                    "name": "No gene ID",
                     "product": "acetyltransferase"
                 },
                 {
@@ -244,7 +250,6 @@
                         }
                     ],
                     "id": "EDY47136.1",
-                    "name": "No gene ID",
                     "product": "conserved hypothetical protein"
                 },
                 {
@@ -270,7 +275,6 @@
                         }
                     ],
                     "id": "EDY47138.1",
-                    "name": "No gene ID",
                     "product": "penicillin-binding protein PBP"
                 },
                 {
@@ -283,7 +287,6 @@
                         }
                     ],
                     "id": "EDY47139.1",
-                    "name": "No gene ID",
                     "product": "penicillin-binding protein"
                 },
                 {
@@ -296,7 +299,6 @@
                         }
                     ],
                     "id": "EDY47140.1",
-                    "name": "No gene ID",
                     "product": "cytochrome P450 hydroxylase"
                 },
                 {
@@ -309,7 +311,6 @@
                         }
                     ],
                     "id": "EDY47141.1",
-                    "name": "No gene ID",
                     "product": "RNA polymerase sigma factor SigL"
                 },
                 {
@@ -322,7 +323,6 @@
                         }
                     ],
                     "id": "EDY47142.1",
-                    "name": "No gene ID",
                     "product": "histidine kinase"
                 },
                 {
@@ -335,7 +335,6 @@
                         }
                     ],
                     "id": "EDY47143.1",
-                    "name": "No gene ID",
                     "product": "two-component system response regulator"
                 }
             ]

--- a/data/BGC0000938.json
+++ b/data/BGC0000938.json
@@ -28,6 +28,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.1"
+        },
+        {
+            "comments": [
+                "Removed duplicate gene names"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -72,7 +81,6 @@
             "annotations": [
                 {
                     "id": "ACG70810.1",
-                    "name": "bioH",
                     "product": "putative membrane protein"
                 },
                 {
@@ -82,7 +90,6 @@
                 },
                 {
                     "id": "ACG70812.1",
-                    "name": "fomR",
                     "product": "hypothetical protein"
                 },
                 {
@@ -136,7 +143,6 @@
                 },
                 {
                     "id": "ACG70823.1",
-                    "name": "fomF",
                     "product": "putative antibiotic transport protein"
                 },
                 {
@@ -265,7 +271,6 @@
                         }
                     ],
                     "id": "ACG70835.1",
-                    "name": "phnD",
                     "product": "putative transcriptional regulator"
                 },
                 {

--- a/data/BGC0000938.json
+++ b/data/BGC0000938.json
@@ -20,10 +20,12 @@
         },
         {
             "comments": [
-                "Update compound structure (SMILES) for fosfomycin"
+                "Update compound structure (SMILES) for fosfomycin",
+                "Removed gene names of 'No gene ID'"
             ],
             "contributors": [
-                "H5KVDLSVQ3TJW7SKCDNBDEVC"
+                "H5KVDLSVQ3TJW7SKCDNBDEVC",
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.1"
         }
@@ -98,47 +100,38 @@
                 },
                 {
                     "id": "ACG70814.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
                     "id": "ACG70815.1",
-                    "name": "No gene ID",
                     "product": "mandelate racemase-like protein"
                 },
                 {
                     "id": "ACG70816.1",
-                    "name": "No gene ID",
                     "product": "demethylmenaquinone methyltransferase-like protein"
                 },
                 {
                     "id": "ACG70817.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
                     "id": "ACG70818.1",
-                    "name": "No gene ID",
                     "product": "branched-chain amino acid aminotransferase-like protein"
                 },
                 {
                     "id": "ACG70819.1",
-                    "name": "No gene ID",
                     "product": "putative coenzyme PQQ synthesis protein c"
                 },
                 {
                     "id": "ACG70820.1",
-                    "name": "No gene ID",
                     "product": "HMG-CoA lyase-like protein"
                 },
                 {
                     "id": "ACG70821.1",
-                    "name": "No gene ID",
                     "product": "succinyl-diaminopimelate desuccinylase-like protein"
                 },
                 {
                     "id": "ACG70822.1",
-                    "name": "No gene ID",
                     "product": "Unknown"
                 },
                 {
@@ -260,7 +253,6 @@
                 },
                 {
                     "id": "ACG70834.1",
-                    "name": "No gene ID",
                     "product": "putative dienelactone hydrolase"
                 },
                 {

--- a/data/BGC0000971.json
+++ b/data/BGC0000971.json
@@ -21,7 +21,8 @@
         },
         {
             "comments": [
-                "Corrected NRP module activity"
+                "Corrected NRP module activity",
+                "Remove leading/trailing whitespace in gene identifiers"
             ],
             "contributors": [
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
@@ -184,7 +185,7 @@
                         }
                     ],
                     "id": "CBW54676.1",
-                    "name": "cinF ",
+                    "name": "cinF",
                     "product": "octenoyl-CoA reductase/carboxylase"
                 },
                 {

--- a/data/BGC0000972.json
+++ b/data/BGC0000972.json
@@ -20,7 +20,8 @@
         },
         {
             "comments": [
-                "Corrected NRP module activity"
+                "Corrected NRP module activity",
+                "Removed duplicate gene name"
             ],
             "contributors": [
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
@@ -66,7 +67,6 @@
                 },
                 {
                     "id": "CAJ76282.1",
-                    "name": "clbQ",
                     "product": "hypothetical protein"
                 },
                 {

--- a/data/BGC0000976.json
+++ b/data/BGC0000976.json
@@ -21,7 +21,8 @@
         },
         {
             "comments": [
-                "Corrected NRP module activity"
+                "Corrected NRP module activity",
+                "Removed gene names of 'No gene ID'"
             ],
             "contributors": [
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
@@ -80,7 +81,6 @@
             "annotations": [
                 {
                     "id": "AEE88276.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
@@ -93,7 +93,6 @@
                         }
                     ],
                     "id": "AEE88277.1",
-                    "name": "No gene ID",
                     "product": "CurM"
                 },
                 {
@@ -106,7 +105,6 @@
                         }
                     ],
                     "id": "AEE88278.1",
-                    "name": "No gene ID",
                     "product": "CurL"
                 },
                 {
@@ -119,7 +117,6 @@
                         }
                     ],
                     "id": "AEE88279.1",
-                    "name": "No gene ID",
                     "product": "CurK"
                 },
                 {
@@ -132,7 +129,6 @@
                         }
                     ],
                     "id": "AEE88280.1",
-                    "name": "No gene ID",
                     "product": "CurJ"
                 },
                 {
@@ -145,7 +141,6 @@
                         }
                     ],
                     "id": "AEE88281.1",
-                    "name": "No gene ID",
                     "product": "CurI"
                 },
                 {
@@ -158,7 +153,6 @@
                         }
                     ],
                     "id": "AEE88282.1",
-                    "name": "No gene ID",
                     "product": "CurH"
                 },
                 {
@@ -171,7 +165,6 @@
                         }
                     ],
                     "id": "AEE88283.1",
-                    "name": "No gene ID",
                     "product": "CurG"
                 },
                 {
@@ -184,7 +177,6 @@
                         }
                     ],
                     "id": "AEE88284.1",
-                    "name": "No gene ID",
                     "product": "CurF"
                 },
                 {
@@ -197,7 +189,6 @@
                         }
                     ],
                     "id": "AEE88285.1",
-                    "name": "No gene ID",
                     "product": "CurE",
                     "tailoring": [
                         "Dehydration"
@@ -213,7 +204,6 @@
                         }
                     ],
                     "id": "AEE88286.1",
-                    "name": "No gene ID",
                     "product": "CurD"
                 },
                 {
@@ -226,7 +216,6 @@
                         }
                     ],
                     "id": "AEE88287.1",
-                    "name": "No gene ID",
                     "product": "CurC"
                 },
                 {
@@ -239,7 +228,6 @@
                         }
                     ],
                     "id": "AEE88288.1",
-                    "name": "No gene ID",
                     "product": "CurB"
                 },
                 {
@@ -252,12 +240,10 @@
                         }
                     ],
                     "id": "AEE88289.1",
-                    "name": "No gene ID",
                     "product": "CurA"
                 },
                 {
                     "id": "AEE88290.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 }
             ]

--- a/data/BGC0001001.json
+++ b/data/BGC0001001.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Removed gene names of 'No gene ID'"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -73,22 +82,18 @@
             "annotations": [
                 {
                     "id": "AAS98794.1",
-                    "name": "No gene ID",
                     "product": "sucrose synthase"
                 },
                 {
                     "id": "AAS98795.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
                     "id": "AAS98796.1",
-                    "name": "No gene ID",
                     "product": "putative transposase"
                 },
                 {
                     "id": "AAS98797.1",
-                    "name": "No gene ID",
                     "product": "transposase"
                 },
                 {
@@ -329,27 +334,22 @@
                 },
                 {
                     "id": "AAS98789.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
                     "id": "AAS98790.1",
-                    "name": "No gene ID",
                     "product": "putative transposase"
                 },
                 {
                     "id": "AAS98792.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
                     "id": "AAS98791.1",
-                    "name": "No gene ID",
                     "product": "choloylglycine hydrolase-like protein"
                 },
                 {
                     "id": "AAS98793.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 }
             ]

--- a/data/BGC0001004.json
+++ b/data/BGC0001004.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected polyketide synthase gene entries"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -131,11 +140,11 @@
             "synthases": [
                 {
                     "genes": [
-                        "lobA3, AGI99495.1",
-                        "lobA1, AGI99482.1",
-                        "lobA2, AGI99494.1",
+                        "lobA3",
+                        "lobA1",
+                        "lobA2",
                         "lobA5",
-                        "lobA4, AGI99496.1"
+                        "lobA4"
                     ],
                     "modules": [
                         {
@@ -151,7 +160,7 @@
                             ],
                             "evidence": "Structure-based inference",
                             "genes": [
-                                "lobA1, AGI99482.1"
+                                "lobA1"
                             ],
                             "kr_stereochem": "Unknown",
                             "module_number": "10"
@@ -170,7 +179,7 @@
                             ],
                             "evidence": "Structure-based inference",
                             "genes": [
-                                "lobA1, AGI99482.1"
+                                "lobA1"
                             ],
                             "kr_stereochem": "Unknown",
                             "module_number": "9"
@@ -187,7 +196,7 @@
                             ],
                             "evidence": "Structure-based inference",
                             "genes": [
-                                "lobA2, AGI99494.1"
+                                "lobA2"
                             ],
                             "kr_stereochem": "Unknown",
                             "module_number": "11"
@@ -205,7 +214,7 @@
                             ],
                             "evidence": "Structure-based inference",
                             "genes": [
-                                "lobA3, AGI99495.1"
+                                "lobA3"
                             ],
                             "kr_stereochem": "Unknown",
                             "module_number": "8"
@@ -223,7 +232,7 @@
                             ],
                             "evidence": "Structure-based inference",
                             "genes": [
-                                "lobA4, AGI99496.1"
+                                "lobA4"
                             ],
                             "kr_stereochem": "Unknown",
                             "module_number": "4"
@@ -241,7 +250,7 @@
                             ],
                             "evidence": "Structure-based inference",
                             "genes": [
-                                "lobA4, AGI99496.1"
+                                "lobA4"
                             ],
                             "kr_stereochem": "Unknown",
                             "module_number": "5"
@@ -258,7 +267,7 @@
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
-                                "lobA4, AGI99496.1"
+                                "lobA4"
                             ],
                             "kr_stereochem": "Unknown",
                             "module_number": "6"
@@ -274,7 +283,7 @@
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
-                                "lobA4, AGI99496.1"
+                                "lobA4"
                             ],
                             "kr_stereochem": "Unknown",
                             "module_number": "7"

--- a/data/BGC0001010.json
+++ b/data/BGC0001010.json
@@ -21,7 +21,8 @@
         },
         {
             "comments": [
-                "Corrected NRP module activity"
+                "Corrected NRP module activity",
+                "Remove leading/trailing whitespace in gene identifiers"
             ],
             "contributors": [
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
@@ -78,7 +79,7 @@
                         }
                     ],
                     "id": "CAD89774.1",
-                    "name": "melC "
+                    "name": "melC"
                 },
                 {
                     "functions": [
@@ -102,7 +103,7 @@
                         }
                     ],
                     "id": "CAD89776.1",
-                    "name": "melE "
+                    "name": "melE"
                 },
                 {
                     "functions": [

--- a/data/BGC0001024.json
+++ b/data/BGC0001024.json
@@ -21,7 +21,8 @@
         },
         {
             "comments": [
-                "Corrected NRP module activity"
+                "Corrected NRP module activity",
+                "Remove leading/trailing whitespace in gene identifiers"
             ],
             "contributors": [
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
@@ -78,7 +79,7 @@
                         }
                     ],
                     "id": "AAF19810.1",
-                    "name": "mtaB "
+                    "name": "mtaB"
                 },
                 {
                     "functions": [
@@ -90,7 +91,7 @@
                         }
                     ],
                     "id": "AAF19811.1",
-                    "name": "mtaC ",
+                    "name": "mtaC",
                     "product": "mtaC"
                 },
                 {
@@ -127,7 +128,7 @@
                         }
                     ],
                     "id": "AAF19814.1",
-                    "name": "mtaF "
+                    "name": "mtaF"
                 },
                 {
                     "functions": [
@@ -139,7 +140,7 @@
                         }
                     ],
                     "id": "AAF19815.1",
-                    "name": "mtaG ",
+                    "name": "mtaG",
                     "product": "mtaG"
                 }
             ]

--- a/data/BGC0001028.json
+++ b/data/BGC0001028.json
@@ -21,7 +21,8 @@
         },
         {
             "comments": [
-                "Corrected NRP module activity"
+                "Corrected NRP module activity",
+                "Removed duplicate gene name"
             ],
             "contributors": [
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
@@ -101,7 +102,6 @@
                 },
                 {
                     "id": "AAF17282.1",
-                    "name": "nosE",
                     "product": "Unknown"
                 },
                 {

--- a/data/BGC0001037.json
+++ b/data/BGC0001037.json
@@ -21,7 +21,8 @@
         },
         {
             "comments": [
-                "Corrected NRP module activity"
+                "Corrected NRP module activity",
+                "Removed gene names of 'No gene ID'"
             ],
             "contributors": [
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
@@ -145,7 +146,6 @@
                         }
                     ],
                     "id": "EAL85110.1",
-                    "name": "No gene ID",
                     "product": "alpha/beta hydrolase, putative"
                 }
             ]

--- a/data/BGC0001051.json
+++ b/data/BGC0001051.json
@@ -21,7 +21,8 @@
         },
         {
             "comments": [
-                "Corrected NRP module activity"
+                "Corrected NRP module activity",
+                "Remove leading/trailing whitespace in gene identifiers"
             ],
             "contributors": [
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
@@ -72,7 +73,7 @@
                         }
                     ],
                     "id": "ADH04640.1",
-                    "name": "tgaB "
+                    "name": "tgaB"
                 },
                 {
                     "functions": [
@@ -84,7 +85,7 @@
                         }
                     ],
                     "id": "ADH04641.1",
-                    "name": "tgaC "
+                    "name": "tgaC"
                 },
                 {
                     "functions": [
@@ -96,7 +97,7 @@
                         }
                     ],
                     "id": "ADH04642.1",
-                    "name": "tgaD ",
+                    "name": "tgaD",
                     "product": "alcohol dehydrogenase",
                     "tailoring": [
                         "Oxidation"
@@ -112,7 +113,7 @@
                         }
                     ],
                     "id": "ADH04638.1",
-                    "name": "tgaE ",
+                    "name": "tgaE",
                     "product": "monooxygenase",
                     "tailoring": [
                         "Oxidation"

--- a/data/BGC0001066.json
+++ b/data/BGC0001066.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Remove leading/trailing whitespace in gene identifiers"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -66,7 +75,7 @@
                         }
                     ],
                     "id": "CAQ52621.1",
-                    "name": "ken1 ",
+                    "name": "ken1",
                     "product": "type II thioesterase"
                 },
                 {
@@ -79,7 +88,7 @@
                         }
                     ],
                     "id": "CAQ52622.1",
-                    "name": "ken12 "
+                    "name": "ken12"
                 },
                 {
                     "functions": [
@@ -91,7 +100,7 @@
                         }
                     ],
                     "id": "CAQ52623.1",
-                    "name": "ken13 "
+                    "name": "ken13"
                 },
                 {
                     "functions": [
@@ -159,7 +168,7 @@
                         }
                     ],
                     "id": "CAQ52620.1",
-                    "name": "ken2 ",
+                    "name": "ken2",
                     "product": "type III polyketide synthase"
                 },
                 {
@@ -172,7 +181,7 @@
                         }
                     ],
                     "id": "CAQ52619.1",
-                    "name": "ken3 ",
+                    "name": "ken3",
                     "product": "enoyl-CoA hydratase/isomerase"
                 },
                 {
@@ -237,7 +246,7 @@
                         }
                     ],
                     "id": "CAQ52614.1",
-                    "name": "ken9 ",
+                    "name": "ken9",
                     "product": "methyl transferase"
                 }
             ]

--- a/data/BGC0001067.json
+++ b/data/BGC0001067.json
@@ -21,7 +21,8 @@
         },
         {
             "comments": [
-                "Add additional publications"
+                "Add additional publications",
+                "Removed gene names of 'No gene ID'"
             ],
             "contributors": [
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
@@ -181,7 +182,6 @@
                         }
                     ],
                     "id": "EAL85123.1",
-                    "name": "No gene ID",
                     "product": "conserved hypothetical protein"
                 },
                 {
@@ -261,7 +261,6 @@
                         }
                     ],
                     "id": "EAL85117.1",
-                    "name": "No gene ID",
                     "product": "acetate-CoA ligase, putative"
                 },
                 {

--- a/data/BGC0001070.json
+++ b/data/BGC0001070.json
@@ -20,7 +20,8 @@
         },
         {
             "comments": [
-                "Corrected NRP module activity"
+                "Corrected NRP module activity",
+                "Removed duplicate gene annotation"
             ],
             "contributors": [
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
@@ -62,7 +63,7 @@
                 {
                     "functions": [
                         {
-                            "category": "Unknown",
+                            "category": "Precursor biosynthesis",
                             "evidence": [
                                 "Activity assay"
                             ]
@@ -102,17 +103,6 @@
                         }
                     ],
                     "id": "CAN89643.1"
-                },
-                {
-                    "functions": [
-                        {
-                            "category": "Precursor biosynthesis",
-                            "evidence": [
-                                "Activity assay"
-                            ]
-                        }
-                    ],
-                    "id": "CAN89641.1"
                 }
             ]
         },

--- a/data/BGC0001072.json
+++ b/data/BGC0001072.json
@@ -22,9 +22,11 @@
         },
         {
             "comments": [
-                "Remove duplicated citations"
+                "Remove duplicated citations",
+                "Corrected polyketide synthase gene entries"
             ],
             "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA",
                 "3UOU7PODQJXIM6BEPUHHRRA5"
             ],
             "version": "2.1"
@@ -219,7 +221,9 @@
                         "AAK06783.1",
                         "AAK06788.1",
                         "AAK06784.1",
-                        "AEU17897.1,AEU17898.1,AEU17899.1",
+                        "AEU17897.1",
+                        "AEU17898.1",
+                        "AEU17899.1",
                         "AAK06786.1"
                     ],
                     "modules": [
@@ -233,7 +237,7 @@
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
-                                "AEU17897.1,AEU17898.1,AEU17899.1"
+                                "AEU17899.1"
                             ],
                             "kr_stereochem": "Unknown",
                             "module_number": "0"
@@ -250,7 +254,7 @@
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
-                                "AEU17897.1,AEU17898.1,AEU17899.1"
+                                "AEU17899.1"
                             ],
                             "kr_stereochem": "Unknown",
                             "module_number": "1"
@@ -266,7 +270,7 @@
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
-                                "AEU17897.1,AEU17898.1,AEU17899.1"
+                                "AEU17899.1"
                             ],
                             "kr_stereochem": "Unknown",
                             "module_number": "2"
@@ -284,7 +288,7 @@
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
-                                "AEU17897.1,AEU17898.1,AEU17899.1"
+                                "AEU17897.1"
                             ],
                             "kr_stereochem": "Unknown",
                             "module_number": "3"
@@ -299,7 +303,7 @@
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
-                                "AEU17897.1,AEU17898.1,AEU17899.1"
+                                "AEU17898.1"
                             ],
                             "kr_stereochem": "Unknown",
                             "module_number": "4"

--- a/data/BGC0001083.json
+++ b/data/BGC0001083.json
@@ -19,6 +19,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected polyketide synthase gene entries"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -733,7 +742,6 @@
             "synthases": [
                 {
                     "genes": [
-                        "mcl17,agh68902.1",
                         "AGH68902.1"
                     ],
                     "modules": [
@@ -763,12 +771,10 @@
         "terpene": {
             "carbon_count_subclass": "Sesquiterpene",
             "prenyltransferases": [
-                "mcl23",
                 "AGH68908.1"
             ],
             "terpene_precursor": "DMAPP",
             "terpene_synth_cycl": [
-                "mcl22",
                 "AGH68907.1"
             ]
         }

--- a/data/BGC0001089.json
+++ b/data/BGC0001089.json
@@ -21,7 +21,8 @@
         {
             "comments": [
                 "Linked new PubChem id for bacillaene (pubchem:25144999)",
-                "Corrected NRP module activity"
+                "Corrected NRP module activity",
+                "Changed annotations to use correct gene idenitifers"
             ],
             "contributors": [
                 "5UL74VURKJ25VSPPPO3H2NYB",
@@ -61,7 +62,7 @@
                             ]
                         }
                     ],
-                    "id": "YP001421284",
+                    "id": "baeB",
                     "name": "baeB",
                     "product": "hydroxyacylglutathione hydrolase"
                 },
@@ -74,7 +75,7 @@
                             ]
                         }
                     ],
-                    "id": "YP001421285",
+                    "id": "baeC",
                     "name": "baeC",
                     "product": "malonyl-CoA-[acyl-carrier-protein] transacylase [AT]"
                 },
@@ -87,7 +88,7 @@
                             ]
                         }
                     ],
-                    "id": "YP001421286",
+                    "id": "baeD",
                     "name": "baeD",
                     "product": "malonyl-CoA-[acyl-carrier-protein] transacylase [AT]"
                 },
@@ -100,7 +101,7 @@
                             ]
                         }
                     ],
-                    "id": "YP001421287",
+                    "id": "baeE",
                     "name": "baeE",
                     "product": "malonyl-CoA-[acyl-carrier protein] transacylase [AT]/oxidoreductase [OR]"
                 },
@@ -113,7 +114,7 @@
                             ]
                         }
                     ],
-                    "id": "YP001421288",
+                    "id": "acpK",
                     "name": "acpK",
                     "product": "acyl carrier protein"
                 },
@@ -126,7 +127,7 @@
                             ]
                         }
                     ],
-                    "id": "YP001421289",
+                    "id": "baeG",
                     "name": "baeG",
                     "product": "3-hydroxy-3-methylglutaryl CoA synthase"
                 },
@@ -139,7 +140,7 @@
                             ]
                         }
                     ],
-                    "id": "YP001421290",
+                    "id": "baeH",
                     "name": "baeH",
                     "product": "polyketide biosynthesis enoyl-CoA hydratase"
                 },
@@ -152,7 +153,7 @@
                             ]
                         }
                     ],
-                    "id": "YP001421291",
+                    "id": "baeI",
                     "name": "baeI",
                     "product": "polyketide biosynthesis enoyl-CoA hydratase"
                 },
@@ -165,7 +166,7 @@
                             ]
                         }
                     ],
-                    "id": "YP001421292",
+                    "id": "baeJ",
                     "name": "baeJ",
                     "product": "hybrid NRPS/PKS protein"
                 },
@@ -178,7 +179,7 @@
                             ]
                         }
                     ],
-                    "id": "YP001421293",
+                    "id": "baeL",
                     "name": "baeL",
                     "product": "polyketide synthase of type I"
                 },
@@ -191,7 +192,7 @@
                             ]
                         }
                     ],
-                    "id": "YP001421294",
+                    "id": "baeM",
                     "name": "baeM",
                     "product": "polyketide synthase of type I"
                 },
@@ -204,7 +205,7 @@
                             ]
                         }
                     ],
-                    "id": "YP001421295",
+                    "id": "baeN",
                     "name": "baeN",
                     "product": "hybrid NRPS/PKS protein"
                 },
@@ -217,7 +218,7 @@
                             ]
                         }
                     ],
-                    "id": "YP001421296",
+                    "id": "baeR",
                     "name": "baeR",
                     "product": "polyketide synthase of type I"
                 },
@@ -230,7 +231,7 @@
                             ]
                         }
                     ],
-                    "id": "YP001421297",
+                    "id": "baeS",
                     "name": "baeS",
                     "product": "cytochrome P450 'oxidase'"
                 }
@@ -249,7 +250,7 @@
         "nrp": {
             "nrps_genes": [
                 {
-                    "gene_id": "YP001421292",
+                    "gene_id": "baeJ",
                     "modules": [
                         {
                             "active": true,
@@ -270,7 +271,7 @@
                     ]
                 },
                 {
-                    "gene_id": "YP001421295",
+                    "gene_id": "baeN",
                     "modules": [
                         {
                             "active": true,
@@ -286,11 +287,11 @@
             "synthases": [
                 {
                     "genes": [
-                        "YP001421292",
-                        "YP001421293",
-                        "YP001421295",
-                        "YP001421296",
-                        "YP001421294"
+                        "baeJ",
+                        "baeL",
+                        "baeM",
+                        "baeN",
+                        "baeR"
                     ],
                     "modules": [
                         {
@@ -305,7 +306,7 @@
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
-                                "YP001421292"
+                                "baeJ"
                             ],
                             "kr_stereochem": "Unknown",
                             "module_number": "2"
@@ -320,7 +321,7 @@
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
-                                "YP001421292"
+                                "baeJ"
                             ],
                             "kr_stereochem": "Unknown",
                             "module_number": "3"
@@ -333,7 +334,7 @@
                                 "Ketosynthase"
                             ],
                             "genes": [
-                                "YP001421292"
+                                "baeJ"
                             ],
                             "kr_stereochem": "Unknown",
                             "module_number": "4",
@@ -355,7 +356,7 @@
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
-                                "YP001421293"
+                                "baeL"
                             ],
                             "kr_stereochem": "Unknown",
                             "module_number": "4"
@@ -371,7 +372,7 @@
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
-                                "YP001421293"
+                                "baeL"
                             ],
                             "kr_stereochem": "Unknown",
                             "module_number": "5"
@@ -386,7 +387,7 @@
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
-                                "YP001421293"
+                                "baeL"
                             ],
                             "kr_stereochem": "Unknown",
                             "module_number": "6"
@@ -401,7 +402,7 @@
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
-                                "YP001421293"
+                                "baeL"
                             ],
                             "kr_stereochem": "Unknown",
                             "module_number": "7"
@@ -414,7 +415,7 @@
                                 "Ketosynthase"
                             ],
                             "genes": [
-                                "YP001421293"
+                                "baeL"
                             ],
                             "kr_stereochem": "Unknown",
                             "module_number": "8",
@@ -438,7 +439,7 @@
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
-                                "YP001421294"
+                                "baeM"
                             ],
                             "kr_stereochem": "Unknown",
                             "module_number": "9",
@@ -456,7 +457,7 @@
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
-                                "YP001421294"
+                                "baeM"
                             ],
                             "kr_stereochem": "Unknown",
                             "module_number": "10"
@@ -472,7 +473,7 @@
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
-                                "YP001421295"
+                                "baeN"
                             ],
                             "kr_stereochem": "Unknown",
                             "module_number": "12"
@@ -488,7 +489,7 @@
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
-                                "YP001421295"
+                                "baeN"
                             ],
                             "kr_stereochem": "Unknown",
                             "module_number": "13"
@@ -503,7 +504,7 @@
                                 "Ketoreductase"
                             ],
                             "genes": [
-                                "YP001421295"
+                                "baeN"
                             ],
                             "kr_stereochem": "Unknown",
                             "module_number": "14"
@@ -516,7 +517,7 @@
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
-                                "YP001421296"
+                                "baeR"
                             ],
                             "kr_stereochem": "Unknown",
                             "module_number": "15",
@@ -534,7 +535,7 @@
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
-                                "YP001421296"
+                                "baeR"
                             ],
                             "kr_stereochem": "Unknown",
                             "module_number": "16",
@@ -557,7 +558,7 @@
                                 "Thioesterase"
                             ],
                             "genes": [
-                                "YP001421296"
+                                "baeR"
                             ],
                             "kr_stereochem": "Unknown",
                             "module_number": "17",

--- a/data/BGC0001099.json
+++ b/data/BGC0001099.json
@@ -21,7 +21,8 @@
         },
         {
             "comments": [
-                "Corrected NRP module activity"
+                "Corrected NRP module activity",
+                "Corrected polyketide synthase gene entries"
             ],
             "contributors": [
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
@@ -324,7 +325,8 @@
             "synthases": [
                 {
                     "genes": [
-                        "ADD82949.1, ADD82951.1",
+                        "ADD82949.1",
+                        "ADD82951.1",
                         "ADD82940.1",
                         "ADD82941.1",
                         "ADD82939.1"

--- a/data/BGC0001108.json
+++ b/data/BGC0001108.json
@@ -21,7 +21,8 @@
         {
             "comments": [
                 "Removed gene names of 'No gene ID'",
-                "Corrected duplicated gene annotation"
+                "Corrected duplicated gene annotation",
+                "Removed duplicate gene name"
             ],
             "contributors": [
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
@@ -118,7 +119,6 @@
                         }
                     ],
                     "id": "AAS47549.1",
-                    "name": "pedA",
                     "product": "putative dioxygenase",
                     "tailoring": [
                         "Dioxygenation"

--- a/data/BGC0001108.json
+++ b/data/BGC0001108.json
@@ -20,7 +20,8 @@
         },
         {
             "comments": [
-                "Removed gene names of 'No gene ID'"
+                "Removed gene names of 'No gene ID'",
+                "Corrected duplicated gene annotation"
             ],
             "contributors": [
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
@@ -200,18 +201,15 @@
                 {
                     "functions": [
                         {
-                            "category": "Tailoring",
+                            "category": "Scaffold biosynthesis",
                             "evidence": [
                                 "Sequence-based prediction"
                             ]
                         }
                     ],
-                    "id": "AAS47560.1",
-                    "name": "pedE",
-                    "product": "putative methyltransferase",
-                    "tailoring": [
-                        "Methylation"
-                    ]
+                    "id": "AAS47564.1",
+                    "name": "pedF",
+                    "product": "mixed type I polyketide synthase/nonribosomal peptide synthetase"
                 },
                 {
                     "functions": [

--- a/data/BGC0001108.json
+++ b/data/BGC0001108.json
@@ -17,6 +17,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Removed gene names of 'No gene ID'"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -96,7 +105,6 @@
                         }
                     ],
                     "id": "AAS47548.1",
-                    "name": "No gene ID",
                     "product": "putative isocitrate dehydrogenase kinase/phosphatase"
                 },
                 {
@@ -244,7 +252,6 @@
                         }
                     ],
                     "id": "AAS47550.1",
-                    "name": "No gene ID",
                     "product": "putative acyl carrier protein"
                 },
                 {
@@ -257,7 +264,6 @@
                         }
                     ],
                     "id": "AAS47551.1",
-                    "name": "No gene ID",
                     "product": "putative DNA helicase"
                 },
                 {
@@ -270,7 +276,6 @@
                         }
                     ],
                     "id": "AAS47552.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
@@ -283,7 +288,6 @@
                         }
                     ],
                     "id": "AAS47553.1",
-                    "name": "No gene ID",
                     "product": "putative RNA methylase"
                 },
                 {
@@ -296,7 +300,6 @@
                         }
                     ],
                     "id": "AAS47554.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
@@ -309,7 +312,6 @@
                         }
                     ],
                     "id": "AAS47555.1",
-                    "name": "No gene ID",
                     "product": "putative aldehyde dehydrogenase"
                 }
             ]

--- a/data/BGC0001111.json
+++ b/data/BGC0001111.json
@@ -21,7 +21,8 @@
         },
         {
             "comments": [
-                "Corrected NRP module activity"
+                "Corrected NRP module activity",
+                "Remove leading/trailing whitespace in gene identifiers"
             ],
             "contributors": [
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
@@ -85,7 +86,7 @@
                         }
                     ],
                     "id": "CCA89327.1",
-                    "name": "rizC ",
+                    "name": "rizC",
                     "product": "trans-AT type I polyketide synthase"
                 },
                 {

--- a/data/BGC0001112.json
+++ b/data/BGC0001112.json
@@ -20,7 +20,8 @@
         },
         {
             "comments": [
-                "Corrected NRP module activity"
+                "Corrected NRP module activity",
+                "Corrected polyketide synthase gene entries"
             ],
             "contributors": [
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
@@ -85,7 +86,7 @@
             "cyclic": false,
             "nrps_genes": [
                 {
-                    "gene_id": "rhiA, CAL69888.1",
+                    "gene_id": "CAL69888.1",
                     "modules": [
                         {
                             "active": true,
@@ -95,7 +96,7 @@
                     ]
                 },
                 {
-                    "gene_id": "rhiB, CAL69889.1",
+                    "gene_id": "CAL69889.1",
                     "modules": [
                         {
                             "a_substr_spec": {
@@ -136,13 +137,13 @@
             "synthases": [
                 {
                     "genes": [
-                        "rhiD, CAL69891.1",
-                        "rhiF, CAL69893.1",
-                        "rhiE, CAL69892.1",
+                        "rhiD",
+                        "rhiF",
+                        "rhiE",
                         "rhiG",
-                        "rhiA, CAL69888.1",
-                        "rhiB, CAL69889.1",
-                        "rhiC, CAL69890.1",
+                        "rhiA",
+                        "rhiB",
+                        "rhiC",
                         "am411073"
                     ],
                     "modules": [
@@ -154,7 +155,7 @@
                                 "Ketosynthase"
                             ],
                             "genes": [
-                                "rhiA, CAL69888.1"
+                                "rhiA"
                             ],
                             "kr_stereochem": "Unknown",
                             "module_number": "0"
@@ -170,7 +171,7 @@
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
-                                "rhiB, CAL69889.1"
+                                "rhiB"
                             ],
                             "kr_stereochem": "L-OH",
                             "module_number": "1",
@@ -190,7 +191,7 @@
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
-                                "rhiB, CAL69889.1"
+                                "rhiB"
                             ],
                             "kr_stereochem": "L-OH",
                             "module_number": "2"
@@ -205,7 +206,7 @@
                                 "Ketoreductase"
                             ],
                             "genes": [
-                                "rhiB, CAL69889.1"
+                                "rhiB"
                             ],
                             "kr_stereochem": "L-OH",
                             "module_number": "3"
@@ -218,7 +219,7 @@
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
-                                "rhiC, CAL69890.1"
+                                "rhiC"
                             ],
                             "kr_stereochem": "Unknown",
                             "module_number": "3",
@@ -236,7 +237,7 @@
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
-                                "rhiC, CAL69890.1"
+                                "rhiC"
                             ],
                             "kr_stereochem": "D-OH",
                             "module_number": "4",
@@ -254,7 +255,7 @@
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
-                                "rhiC, CAL69890.1"
+                                "rhiC"
                             ],
                             "kr_stereochem": "L-OH",
                             "module_number": "5"
@@ -270,7 +271,7 @@
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
-                                "rhiC, CAL69890.1"
+                                "rhiC"
                             ],
                             "kr_stereochem": "D-OH",
                             "module_number": "6"
@@ -286,7 +287,7 @@
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
-                                "rhiD, CAL69891.1"
+                                "rhiD"
                             ],
                             "kr_stereochem": "L-OH",
                             "module_number": "7"
@@ -302,7 +303,7 @@
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
-                                "rhiD, CAL69891.1"
+                                "rhiD"
                             ],
                             "kr_stereochem": "L-OH",
                             "module_number": "8",
@@ -321,7 +322,7 @@
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
-                                "rhiE, CAL69892.1"
+                                "rhiE"
                             ],
                             "kr_stereochem": "L-OH",
                             "module_number": "10"
@@ -335,7 +336,7 @@
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
-                                "rhiE, CAL69892.1"
+                                "rhiE"
                             ],
                             "kr_stereochem": "Unknown",
                             "module_number": "11",
@@ -355,7 +356,7 @@
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
-                                "rhiE, CAL69892.1"
+                                "rhiE"
                             ],
                             "kr_stereochem": "D-OH",
                             "module_number": "9"
@@ -371,7 +372,7 @@
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
-                                "rhiF, CAL69893.1"
+                                "rhiF"
                             ],
                             "kr_stereochem": "L-OH",
                             "module_number": "12"

--- a/data/BGC0001114.json
+++ b/data/BGC0001114.json
@@ -21,7 +21,8 @@
         },
         {
             "comments": [
-                "Removed gene names of 'No gene ID'"
+                "Removed gene names of 'No gene ID'",
+                "Removed duplicated gene identifier"
             ],
             "contributors": [
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
@@ -91,7 +92,6 @@
                         }
                     ],
                     "id": "AGN11879.1",
-                    "name": "tstA",
                     "product": "putative alkyl hydroperoxide reductase subunit C"
                 },
                 {

--- a/data/BGC0001114.json
+++ b/data/BGC0001114.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Removed gene names of 'No gene ID'"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -58,7 +67,6 @@
                         }
                     ],
                     "id": "AGN11877.1",
-                    "name": "No gene ID",
                     "product": "putative transcriptional regulator"
                 },
                 {
@@ -71,7 +79,6 @@
                         }
                     ],
                     "id": "AGN11878.1",
-                    "name": "No gene ID",
                     "product": "putative alkyl hydroperoxide reductase subunit F"
                 },
                 {
@@ -301,7 +308,6 @@
                         }
                     ],
                     "id": "AGN11894.1",
-                    "name": "No gene ID",
                     "product": "TrpC indole-3-glycerol phosphate synthase"
                 },
                 {
@@ -314,7 +320,6 @@
                         }
                     ],
                     "id": "AGN11895.1",
-                    "name": "No gene ID",
                     "product": "ExoU type III effector protein"
                 }
             ]

--- a/data/BGC0001167.json
+++ b/data/BGC0001167.json
@@ -20,10 +20,12 @@
         },
         {
             "comments": [
-                "Remove negative molecular mass"
+                "Remove negative molecular mass",
+                "Removed gene names of 'No gene ID'"
             ],
             "contributors": [
-                "3UOU7PODQJXIM6BEPUHHRRA5"
+                "3UOU7PODQJXIM6BEPUHHRRA5",
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.1"
         }
@@ -91,7 +93,6 @@
                         }
                     ],
                     "id": "AFK79990.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
@@ -104,7 +105,6 @@
                         }
                     ],
                     "id": "AFK79991.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
@@ -117,7 +117,6 @@
                         }
                     ],
                     "id": "AFK79992.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
@@ -182,7 +181,6 @@
                         }
                     ],
                     "id": "AFK79997.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {

--- a/data/BGC0001171.json
+++ b/data/BGC0001171.json
@@ -20,10 +20,12 @@
         },
         {
             "comments": [
-                "Remove negative molecular mass"
+                "Remove negative molecular mass",
+                "Remove leading/trailing whitespace in gene identifiers"
             ],
             "contributors": [
-                "3UOU7PODQJXIM6BEPUHHRRA5"
+                "3UOU7PODQJXIM6BEPUHHRRA5",
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.1"
         }
@@ -129,7 +131,7 @@
                         }
                     ],
                     "id": "LMOf2365_1119",
-                    "name": "llsE ",
+                    "name": "llsE",
                     "product": "Putative protease"
                 }
             ]

--- a/data/BGC0001231.json
+++ b/data/BGC0001231.json
@@ -20,7 +20,8 @@
         },
         {
             "comments": [
-                "Corrected NRP module activity"
+                "Corrected NRP module activity",
+                "Fixed incorrect gene identifiers"
             ],
             "contributors": [
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
@@ -100,7 +101,7 @@
                             ]
                         }
                     ],
-                    "id": "mscC",
+                    "id": "mscD",
                     "name": "mscD"
                 },
                 {
@@ -213,7 +214,7 @@
                             ]
                         }
                     ],
-                    "id": "mscN",
+                    "id": "mscM",
                     "name": "mscM",
                     "product": "Fe(II)/α-ketoglutarate dependent oxygenase",
                     "tailoring": [

--- a/data/BGC0001285.json
+++ b/data/BGC0001285.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Removed gene names of 'No gene ID'"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -95,7 +104,6 @@
                         }
                     ],
                     "id": "ALJ01853.1",
-                    "name": "No gene ID",
                     "product": "membrane protein"
                 },
                 {
@@ -108,7 +116,6 @@
                         }
                     ],
                     "id": "ALJ01854.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
@@ -121,7 +128,6 @@
                         }
                     ],
                     "id": "ALJ01855.1",
-                    "name": "No gene ID",
                     "product": "putative dioxygenase"
                 },
                 {
@@ -134,7 +140,6 @@
                         }
                     ],
                     "id": "ALJ01856.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
@@ -147,7 +152,6 @@
                         }
                     ],
                     "id": "ALJ01857.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
@@ -173,7 +177,6 @@
                         }
                     ],
                     "id": "ALJ01859.1",
-                    "name": "No gene ID",
                     "product": "glucose-6-phosphate 1-dehydrogenase"
                 },
                 {
@@ -186,7 +189,6 @@
                         }
                     ],
                     "id": "ALJ01860.1",
-                    "name": "No gene ID",
                     "product": "6-phosphogluconate dehydrogenase"
                 },
                 {
@@ -199,7 +201,6 @@
                         }
                     ],
                     "id": "ALJ01861.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
@@ -225,7 +226,6 @@
                         }
                     ],
                     "id": "ALJ01863.1",
-                    "name": "No gene ID",
                     "product": "malto-oligosyltrehalose trehalohydrolase"
                 },
                 {
@@ -238,7 +238,6 @@
                         }
                     ],
                     "id": "ALJ01864.1",
-                    "name": "No gene ID",
                     "product": "4-alpha-glucanotransferase"
                 },
                 {
@@ -251,7 +250,6 @@
                         }
                     ],
                     "id": "ALJ01865.1",
-                    "name": "No gene ID",
                     "product": "malto-oligosyltrehalose synthase"
                 },
                 {
@@ -264,7 +262,6 @@
                         }
                     ],
                     "id": "ALJ01866.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
@@ -290,7 +287,6 @@
                         }
                     ],
                     "id": "ALJ01868.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 }
             ]

--- a/data/BGC0001327.json
+++ b/data/BGC0001327.json
@@ -23,7 +23,8 @@
         {
             "comments": [
                 "Corrected NRP module activity",
-                "Removed gene names of 'No gene ID'"
+                "Removed gene names of 'No gene ID'",
+                "Removed gene annotation with no reference name or ID"
             ],
             "contributors": [
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
@@ -129,18 +130,6 @@
                     ],
                     "id": "WP_030498978.1",
                     "product": "hypothetical protein"
-                },
-                {
-                    "functions": [
-                        {
-                            "category": "Scaffold biosynthesis",
-                            "evidence": [
-                                "Sequence-based prediction"
-                            ]
-                        }
-                    ],
-                    "id": "No protein ID",
-                    "product": "gramicidin dehydrogenase"
                 },
                 {
                     "id": "WP_030498980.1",

--- a/data/BGC0001327.json
+++ b/data/BGC0001327.json
@@ -22,7 +22,8 @@
         },
         {
             "comments": [
-                "Corrected NRP module activity"
+                "Corrected NRP module activity",
+                "Removed gene names of 'No gene ID'"
             ],
             "contributors": [
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
@@ -67,7 +68,6 @@
                         }
                     ],
                     "id": "WP_052165465.1",
-                    "name": "No gene ID",
                     "product": "type I polyketide synthase"
                 },
                 {
@@ -80,7 +80,6 @@
                         }
                     ],
                     "id": "WP_030498974.1",
-                    "name": "No gene ID",
                     "product": "tyrocidine synthase 3"
                 },
                 {
@@ -93,7 +92,6 @@
                         }
                     ],
                     "id": "WP_030498975.1",
-                    "name": "No gene ID",
                     "product": "type I polyketide synthase"
                 },
                 {
@@ -106,7 +104,6 @@
                         }
                     ],
                     "id": "WP_052165466.1",
-                    "name": "No gene ID",
                     "product": "non-ribosomal peptide synthetase"
                 },
                 {
@@ -119,7 +116,6 @@
                         }
                     ],
                     "id": "WP_030498977.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
@@ -132,7 +128,6 @@
                         }
                     ],
                     "id": "WP_030498978.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
@@ -145,12 +140,10 @@
                         }
                     ],
                     "id": "No protein ID",
-                    "name": "No gene ID",
                     "product": "gramicidin dehydrogenase"
                 },
                 {
                     "id": "WP_030498980.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
@@ -163,7 +156,6 @@
                         }
                     ],
                     "id": "WP_030498981.1",
-                    "name": "No gene ID",
                     "product": "clavaminate synthase",
                     "tailoring": [
                         "Monooxygenation"

--- a/data/BGC0001328.json
+++ b/data/BGC0001328.json
@@ -21,7 +21,8 @@
         },
         {
             "comments": [
-                "Corrected NRP module activity"
+                "Corrected NRP module activity",
+                "Removed gene names of 'No gene ID'"
             ],
             "contributors": [
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
@@ -104,7 +105,6 @@
                         }
                     ],
                     "id": "EWM62997.1",
-                    "name": "No gene ID",
                     "product": "non-ribosomal peptide synthetase"
                 },
                 {
@@ -117,7 +117,6 @@
                         }
                     ],
                     "id": "EWM62998.1",
-                    "name": "No gene ID",
                     "product": "mycocerosic acid synthase"
                 },
                 {
@@ -130,7 +129,6 @@
                         }
                     ],
                     "id": "EWM62999.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
@@ -143,7 +141,6 @@
                         }
                     ],
                     "id": "EWM63000.1",
-                    "name": "No gene ID",
                     "product": "non-ribosomal peptide synthetase"
                 },
                 {
@@ -156,7 +153,6 @@
                         }
                     ],
                     "id": "EWM63001.1",
-                    "name": "No gene ID",
                     "product": "polyketide synthase type I"
                 },
                 {
@@ -169,7 +165,6 @@
                         }
                     ],
                     "id": "EWM63002.1",
-                    "name": "No gene ID",
                     "product": "non-ribosomal peptide synthetase"
                 },
                 {
@@ -182,7 +177,6 @@
                         }
                     ],
                     "id": "EWM63003.1",
-                    "name": "No gene ID",
                     "product": "polyketide synthase type I"
                 },
                 {
@@ -195,7 +189,6 @@
                         }
                     ],
                     "id": "EWM63004.1",
-                    "name": "No gene ID",
                     "product": "polyketide synthase type I"
                 },
                 {
@@ -208,7 +201,6 @@
                         }
                     ],
                     "id": "EWM63005.1",
-                    "name": "No gene ID",
                     "product": "linear gramicidin synthetase LgrC"
                 },
                 {
@@ -221,7 +213,6 @@
                         }
                     ],
                     "id": "EWM63006.1",
-                    "name": "No gene ID",
                     "product": "linear gramicidin synthetase LgrD"
                 },
                 {
@@ -234,7 +225,6 @@
                         }
                     ],
                     "id": "EWM63007.1",
-                    "name": "No gene ID",
                     "product": "linear gramicidin synthetase LgrC"
                 },
                 {
@@ -247,7 +237,6 @@
                         }
                     ],
                     "id": "EWM63008.1",
-                    "name": "No gene ID",
                     "product": "pyoverdine ABC transporter permease/ATP-binding protein"
                 },
                 {
@@ -260,7 +249,6 @@
                         }
                     ],
                     "id": "EWM63009.1",
-                    "name": "No gene ID",
                     "product": "gramicidin S biosynthesis protein GrsT"
                 },
                 {
@@ -273,7 +261,6 @@
                         }
                     ],
                     "id": "EWM63011.1",
-                    "name": "No gene ID",
                     "product": "clavaminate synthase"
                 }
             ]

--- a/data/BGC0001331.json
+++ b/data/BGC0001331.json
@@ -21,7 +21,8 @@
         },
         {
             "comments": [
-                "Corrected NRP module activity"
+                "Corrected NRP module activity",
+                "Removed gene names of 'No gene ID'"
             ],
             "contributors": [
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
@@ -240,7 +241,6 @@
                         }
                     ],
                     "id": "WP_019032749.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
@@ -253,7 +253,6 @@
                         }
                     ],
                     "id": "WP_019032750.1",
-                    "name": "No gene ID",
                     "product": "multidrug ABC transporter ATP-binding protein"
                 },
                 {
@@ -266,7 +265,6 @@
                         }
                     ],
                     "id": "WP_019032752.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
@@ -279,7 +277,6 @@
                         }
                     ],
                     "id": "WP_019032753.1",
-                    "name": "No gene ID",
                     "product": "non-ribosomal peptide synthetase"
                 },
                 {
@@ -292,7 +289,6 @@
                         }
                     ],
                     "id": "WP_019032754.1",
-                    "name": "No gene ID",
                     "product": "type I polyketide synthase"
                 },
                 {
@@ -305,7 +301,6 @@
                         }
                     ],
                     "id": "WP_019032755.1",
-                    "name": "No gene ID",
                     "product": "non-ribosomal peptide synthetase"
                 },
                 {
@@ -318,7 +313,6 @@
                         }
                     ],
                     "id": "WP_019032756.1",
-                    "name": "No gene ID",
                     "product": "type I polyketide synthase"
                 },
                 {
@@ -331,7 +325,6 @@
                         }
                     ],
                     "id": "WP_019032757.1",
-                    "name": "No gene ID",
                     "product": "type I polyketide synthase"
                 },
                 {
@@ -344,7 +337,6 @@
                         }
                     ],
                     "id": "WP_019032758.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein",
                     "tailoring": [
                         "Monooxygenation"

--- a/data/BGC0001348.json
+++ b/data/BGC0001348.json
@@ -17,6 +17,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Fixed missing and incorrect gene identifiers"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -60,7 +69,7 @@
                         }
                     ],
                     "id": "WP_063764077.1",
-                    "name": "hbaAIab",
+                    "name": "hbaAI",
                     "product": "hypothetical protein"
                 },
                 {
@@ -85,7 +94,7 @@
                             ]
                         }
                     ],
-                    "id": "No protein ID",
+                    "id": "IF55_RS32375",
                     "name": "hbaAIII",
                     "product": "beta-ketoacyl synthase"
                 },
@@ -98,7 +107,7 @@
                             ]
                         }
                     ],
-                    "id": "No protein ID",
+                    "id": "WP_037966908.1",
                     "name": "hbaAIV",
                     "product": "polyketide synthase"
                 },
@@ -150,7 +159,7 @@
                             ]
                         }
                     ],
-                    "id": "No protein ID",
+                    "id": "WP_078645621.1",
                     "name": "hbaD",
                     "product": "acyl-CoA dehydrogenase"
                 },
@@ -207,6 +216,7 @@
                     "product": "oleoyl-ACP hydrolase"
                 },
                 {
+                    "comments": "Derived by automated computational analysis using gene prediction method: Protein Homology.",
                     "functions": [
                         {
                             "category": "Unknown",
@@ -215,7 +225,7 @@
                             ]
                         }
                     ],
-                    "id": "WP_037966912.1",
+                    "id": "IF55_RS32425",
                     "name": "hbaI",
                     "product": "transcriptional regulator"
                 },
@@ -249,11 +259,6 @@
                     "comments": "incomplete; partial in the middle of a contig; missing stop; Derived by automated computational analysis using gene prediction method: Protein Homology.",
                     "id": "IF55_RS36525",
                     "product": "polyketide synthase"
-                },
-                {
-                    "comments": "Derived by automated computational analysis using gene prediction method: Protein Homology.",
-                    "id": "IF55_RS32425",
-                    "product": "transcriptional regulator"
                 }
             ],
             "extra_genes": [

--- a/data/BGC0001433.json
+++ b/data/BGC0001433.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Removed comment with no information"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -463,6 +472,5 @@
         "publications": [
             "doi:10.3389/fmicb.2017.00194"
         ]
-    },
-    "comments": "No coments"
+    }
 }

--- a/data/BGC0001438.json
+++ b/data/BGC0001438.json
@@ -20,7 +20,8 @@
         },
         {
             "comments": [
-                "Remove negative ketide_length"
+                "Remove negative ketide_length",
+                "Added missing id in gene annotation"
             ],
             "contributors": [
                 "3UOU7PODQJXIM6BEPUHHRRA5"
@@ -409,7 +410,7 @@
                             ]
                         }
                     ],
-                    "id": "No protein ID",
+                    "id": "B9W61_07270",
                     "name": "wmc23",
                     "product": "monooxygenase"
                 },

--- a/data/BGC0001445.json
+++ b/data/BGC0001445.json
@@ -17,6 +17,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Removed gene names of 'No gene ID'"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -53,7 +62,6 @@
                         }
                     ],
                     "id": "EED49868.1",
-                    "name": "No gene ID",
                     "product": "conserved hypothetical protein"
                 }
             ]

--- a/data/BGC0001446.json
+++ b/data/BGC0001446.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Removed gene names of 'No gene ID'"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -54,7 +63,6 @@
                         }
                     ],
                     "id": "EED57517.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
@@ -67,7 +75,6 @@
                         }
                     ],
                     "id": "EED57518.1",
-                    "name": "No gene ID",
                     "product": "polyketide synthase, putative"
                 }
             ]

--- a/data/BGC0001448.json
+++ b/data/BGC0001448.json
@@ -22,7 +22,8 @@
         {
             "comments": [
                 "Corrected NRP module activity",
-                "Removed gene names of 'No gene ID'"
+                "Removed gene names of 'No gene ID'",
+                "Fixed duplicate gene names"
             ],
             "contributors": [
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
@@ -117,7 +118,6 @@
                         }
                     ],
                     "id": "ARU08062.1",
-                    "name": "mlcA",
                     "product": "hypothetical protein"
                 },
                 {
@@ -359,7 +359,6 @@
                         }
                     ],
                     "id": "ARU08081.1",
-                    "name": "mlcN",
                     "product": "hypothetical protein"
                 },
                 {
@@ -411,7 +410,6 @@
                         }
                     ],
                     "id": "ARU08085.1",
-                    "name": "mlcQ",
                     "product": "hypothetical protein"
                 },
                 {
@@ -502,7 +500,6 @@
                         }
                     ],
                     "id": "ARU08092.1",
-                    "name": "mlcW",
                     "product": "hypothetical protein"
                 },
                 {
@@ -528,7 +525,6 @@
                         }
                     ],
                     "id": "ARU08094.1",
-                    "name": "mlcX",
                     "product": "hypothetical protein"
                 },
                 {

--- a/data/BGC0001448.json
+++ b/data/BGC0001448.json
@@ -21,7 +21,8 @@
         },
         {
             "comments": [
-                "Corrected NRP module activity"
+                "Corrected NRP module activity",
+                "Removed gene names of 'No gene ID'"
             ],
             "contributors": [
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
@@ -92,7 +93,6 @@
                         }
                     ],
                     "id": "ARU08060.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
@@ -105,7 +105,6 @@
                         }
                     ],
                     "id": "ARU08061.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
@@ -300,7 +299,6 @@
                         }
                     ],
                     "id": "ARU08076.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
@@ -313,7 +311,6 @@
                         }
                     ],
                     "id": "ARU08077.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
@@ -326,7 +323,6 @@
                         }
                     ],
                     "id": "ARU08078.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
@@ -339,7 +335,6 @@
                         }
                     ],
                     "id": "ARU08079.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
@@ -352,7 +347,6 @@
                         }
                     ],
                     "id": "ARU08080.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
@@ -573,7 +567,6 @@
                         }
                     ],
                     "id": "ARU08097.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
@@ -586,7 +579,6 @@
                         }
                     ],
                     "id": "ARU08098.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 }
             ]

--- a/data/BGC0001477.json
+++ b/data/BGC0001477.json
@@ -21,7 +21,8 @@
         },
         {
             "comments": [
-                "Corrected NRP module activity"
+                "Corrected NRP module activity",
+                "Removed gene names of 'No gene ID'"
             ],
             "contributors": [
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
@@ -65,7 +66,6 @@
                         }
                     ],
                     "id": "AVV61973.1",
-                    "name": "No gene ID",
                     "product": "response regulator"
                 },
                 {
@@ -78,7 +78,6 @@
                         }
                     ],
                     "id": "AVV61974.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
@@ -91,7 +90,6 @@
                         }
                     ],
                     "id": "AVV61975.1",
-                    "name": "No gene ID",
                     "product": "putative signal transduction histidine kinase"
                 },
                 {
@@ -104,7 +102,6 @@
                         }
                     ],
                     "id": "AVV61976.1",
-                    "name": "No gene ID",
                     "product": "LuxR family DNA-binding response regulator"
                 },
                 {
@@ -117,7 +114,6 @@
                         }
                     ],
                     "id": "AVV61977.1",
-                    "name": "No gene ID",
                     "product": "malonyl CoA-acyl carrier protein transacylase"
                 },
                 {
@@ -130,7 +126,6 @@
                         }
                     ],
                     "id": "AVV61978.1",
-                    "name": "No gene ID",
                     "product": "putative secreted protein"
                 },
                 {
@@ -143,7 +138,6 @@
                         }
                     ],
                     "id": "AVV61979.1",
-                    "name": "No gene ID",
                     "product": "beta-ketoacyl synthase"
                 },
                 {
@@ -156,7 +150,6 @@
                         }
                     ],
                     "id": "AVV61980.1",
-                    "name": "No gene ID",
                     "product": "type I modular PKS"
                 },
                 {
@@ -169,7 +162,6 @@
                         }
                     ],
                     "id": "AVV61981.1",
-                    "name": "No gene ID",
                     "product": "type I modular PKS"
                 },
                 {
@@ -182,7 +174,6 @@
                         }
                     ],
                     "id": "AVV61982.1",
-                    "name": "No gene ID",
                     "product": "type I modular PKS"
                 },
                 {
@@ -195,7 +186,6 @@
                         }
                     ],
                     "id": "AVV61983.1",
-                    "name": "No gene ID",
                     "product": "type I modular polyketide synthase"
                 },
                 {
@@ -208,7 +198,6 @@
                         }
                     ],
                     "id": "AVV61984.1",
-                    "name": "No gene ID",
                     "product": "type I modular polyketide synthase"
                 },
                 {
@@ -221,7 +210,6 @@
                         }
                     ],
                     "id": "AVV61985.1",
-                    "name": "No gene ID",
                     "product": "beta-ketoacyl synthase"
                 },
                 {
@@ -234,7 +222,6 @@
                         }
                     ],
                     "id": "AVV61986.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
@@ -247,7 +234,6 @@
                         }
                     ],
                     "id": "AVV61987.1",
-                    "name": "No gene ID",
                     "product": "putative non-ribosomal peptide synthetase"
                 },
                 {
@@ -260,7 +246,6 @@
                         }
                     ],
                     "id": "AVV61988.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
@@ -273,7 +258,6 @@
                         }
                     ],
                     "id": "AVV61989.1",
-                    "name": "No gene ID",
                     "product": "beta-ketoacyl synthase"
                 },
                 {
@@ -286,7 +270,6 @@
                         }
                     ],
                     "id": "AVV61990.1",
-                    "name": "No gene ID",
                     "product": "cytochrome P450"
                 },
                 {
@@ -299,7 +282,6 @@
                         }
                     ],
                     "id": "AVV61991.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
@@ -312,7 +294,6 @@
                         }
                     ],
                     "id": "AVV61992.1",
-                    "name": "No gene ID",
                     "product": "putative membrane protein"
                 },
                 {
@@ -325,7 +306,6 @@
                         }
                     ],
                     "id": "AVV61993.1",
-                    "name": "No gene ID",
                     "product": "biosynthesis thioesterase"
                 },
                 {
@@ -338,7 +318,6 @@
                         }
                     ],
                     "id": "AVV61994.1",
-                    "name": "No gene ID",
                     "product": "amine oxidase"
                 },
                 {
@@ -351,7 +330,6 @@
                         }
                     ],
                     "id": "AVV61995.1",
-                    "name": "No gene ID",
                     "product": "AsnC family transcriptional regulator"
                 },
                 {
@@ -364,7 +342,6 @@
                         }
                     ],
                     "id": "AVV61996.1",
-                    "name": "No gene ID",
                     "product": "amidase"
                 },
                 {
@@ -377,7 +354,6 @@
                         }
                     ],
                     "id": "AVV61997.1",
-                    "name": "No gene ID",
                     "product": "AbgT transporter"
                 }
             ]

--- a/data/BGC0001478.json
+++ b/data/BGC0001478.json
@@ -17,6 +17,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Removed gene names of 'No gene ID'"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -55,7 +64,6 @@
                         }
                     ],
                     "id": "AVV61969.1",
-                    "name": "No gene ID",
                     "product": "DesA"
                 },
                 {
@@ -68,7 +76,6 @@
                         }
                     ],
                     "id": "AVV61970.1",
-                    "name": "No gene ID",
                     "product": "DesB"
                 },
                 {
@@ -81,7 +88,6 @@
                         }
                     ],
                     "id": "AVV61971.1",
-                    "name": "No gene ID",
                     "product": "DesC"
                 },
                 {
@@ -94,7 +100,6 @@
                         }
                     ],
                     "id": "AVV61972.1",
-                    "name": "No gene ID",
                     "product": "DesD"
                 }
             ]

--- a/data/BGC0001842.json
+++ b/data/BGC0001842.json
@@ -11,7 +11,8 @@
         },
         {
             "comments": [
-                "Corrected NRP module activity"
+                "Corrected NRP module activity",
+                "Removed gene names of 'No gene ID'"
             ],
             "contributors": [
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
@@ -52,7 +53,6 @@
                         }
                     ],
                     "id": "ABA73953.1",
-                    "name": "No gene ID",
                     "product": "putative LuxR-family regulatory protein"
                 },
                 {
@@ -105,7 +105,6 @@
                         }
                     ],
                     "id": "ABA73957.1",
-                    "name": "No gene ID",
                     "product": "putative drug-efflux protein"
                 },
                 {
@@ -118,7 +117,6 @@
                         }
                     ],
                     "id": "ABA73958.1",
-                    "name": "No gene ID",
                     "product": "macrolide-specific ABC-type efflux carrier"
                 },
                 {
@@ -131,7 +129,6 @@
                         }
                     ],
                     "id": "ABA73959.1",
-                    "name": "No gene ID",
                     "product": "putative LuxR-family regulatory protein"
                 }
             ]

--- a/data/BGC0001851.json
+++ b/data/BGC0001851.json
@@ -11,7 +11,8 @@
         },
         {
             "comments": [
-                "Removed gene names of 'No gene ID'"
+                "Removed gene names of 'No gene ID'",
+                "Removed gene annotations with no information"
             ],
             "contributors": [
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
@@ -54,10 +55,6 @@
                     "product": "2nd and 3rd ring cyclase"
                 },
                 {
-                    "id": "WP_031146985.1",
-                    "name": "No gene ID"
-                },
-                {
                     "id": "WP_051892794.1",
                     "product": "4-ketoreductase"
                 },
@@ -68,10 +65,6 @@
                 {
                     "id": "WP_031146991.1",
                     "product": "aminomethylase"
-                },
-                {
-                    "id": "WP_078959094.1",
-                    "name": "No gene ID"
                 },
                 {
                     "id": "WP_031146993.1",
@@ -98,10 +91,6 @@
                 {
                     "id": "WP_031147000.1",
                     "product": "4,6-dehydratase"
-                },
-                {
-                    "id": "WP_031147003.1",
-                    "name": "No gene ID"
                 },
                 {
                     "functions": [
@@ -132,10 +121,6 @@
                     "tailoring": [
                         "Demethylation"
                     ]
-                },
-                {
-                    "id": "WP_031147009.1",
-                    "name": "No gene ID"
                 },
                 {
                     "id": "WP_031147011.1",
@@ -180,16 +165,8 @@
                     ]
                 },
                 {
-                    "id": "WP_037631636.1",
-                    "name": "No gene ID"
-                },
-                {
                     "id": "WP_030957368.1",
                     "product": "ABC transporter"
-                },
-                {
-                    "id": "WP_031147032.1",
-                    "name": "No gene ID"
                 },
                 {
                     "id": "WP_031147034.1",

--- a/data/BGC0001851.json
+++ b/data/BGC0001851.json
@@ -8,6 +8,15 @@
                 "K5UBFDWZSYOHS4HI42NVQMJK"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Removed gene names of 'No gene ID'"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -30,22 +39,18 @@
             "annotations": [
                 {
                     "id": "WP_031146977.1",
-                    "name": "No gene ID",
                     "product": "3-ketoreductase"
                 },
                 {
                     "id": "WP_031146979.1",
-                    "name": "No gene ID",
                     "product": "aminotransferase"
                 },
                 {
                     "id": "WP_031146981.1",
-                    "name": "No gene ID",
                     "product": "aminomethylase"
                 },
                 {
                     "id": "WP_031146983.1",
-                    "name": "No gene ID",
                     "product": "2nd and 3rd ring cyclase"
                 },
                 {
@@ -54,17 +59,14 @@
                 },
                 {
                     "id": "WP_051892794.1",
-                    "name": "No gene ID",
                     "product": "4-ketoreductase"
                 },
                 {
                     "id": "WP_031146990.1",
-                    "name": "No gene ID",
                     "product": "acyl carrier protein"
                 },
                 {
                     "id": "WP_031146991.1",
-                    "name": "No gene ID",
                     "product": "aminomethylase"
                 },
                 {
@@ -73,12 +75,10 @@
                 },
                 {
                     "id": "WP_031146993.1",
-                    "name": "No gene ID",
                     "product": "3-methyltransferase"
                 },
                 {
                     "id": "WP_031146995.1",
-                    "name": "No gene ID",
                     "product": "glycosyltransferase",
                     "tailoring": [
                         "Glycosylation"
@@ -86,12 +86,10 @@
                 },
                 {
                     "id": "WP_031146996.1",
-                    "name": "No gene ID",
                     "product": "oxidase"
                 },
                 {
                     "id": "WP_031146998.1",
-                    "name": "No gene ID",
                     "product": "glycosyltransferase",
                     "tailoring": [
                         "Glycosylation"
@@ -99,7 +97,6 @@
                 },
                 {
                     "id": "WP_031147000.1",
-                    "name": "No gene ID",
                     "product": "4,6-dehydratase"
                 },
                 {
@@ -116,7 +113,6 @@
                         }
                     ],
                     "id": "WP_078959125.1",
-                    "name": "No gene ID",
                     "product": "10-decarboxylase",
                     "tailoring": [
                         "Decarboxylation"
@@ -132,7 +128,6 @@
                         }
                     ],
                     "id": "WP_031147007.1",
-                    "name": "No gene ID",
                     "product": "15-methylesterase",
                     "tailoring": [
                         "Demethylation"
@@ -144,37 +139,30 @@
                 },
                 {
                     "id": "WP_031147011.1",
-                    "name": "No gene ID",
                     "product": "4th ring cyclase"
                 },
                 {
                     "id": "WP_031147013.1",
-                    "name": "No gene ID",
                     "product": "monooxygenase"
                 },
                 {
                     "id": "WP_031147015.1",
-                    "name": "No gene ID",
                     "product": "ketosynthase α-subunit"
                 },
                 {
                     "id": "WP_031147017.1",
-                    "name": "No gene ID",
                     "product": "ketosynthase β-subunit"
                 },
                 {
                     "id": "WP_031147019.1",
-                    "name": "No gene ID",
                     "product": "9-ketoreductase"
                 },
                 {
                     "id": "WP_031147021.1",
-                    "name": "No gene ID",
                     "product": "aromatase"
                 },
                 {
                     "id": "WP_031147023.1",
-                    "name": "No gene ID",
                     "product": "glycosyltransferase",
                     "tailoring": [
                         "Glycosylation"
@@ -182,12 +170,10 @@
                 },
                 {
                     "id": "WP_051892705.1",
-                    "name": "No gene ID",
                     "product": "7-ketoreductase"
                 },
                 {
                     "id": "WP_031147027.1",
-                    "name": "No gene ID",
                     "product": "P450-like",
                     "tailoring": [
                         "Glycosylation"
@@ -199,7 +185,6 @@
                 },
                 {
                     "id": "WP_030957368.1",
-                    "name": "No gene ID",
                     "product": "ABC transporter"
                 },
                 {
@@ -208,7 +193,6 @@
                 },
                 {
                     "id": "WP_031147034.1",
-                    "name": "No gene ID",
                     "product": "glycosyltransferase",
                     "tailoring": [
                         "Glycosylation"
@@ -216,7 +200,6 @@
                 },
                 {
                     "id": "WP_031147036.1",
-                    "name": "No gene ID",
                     "product": "11-hydroxylase",
                     "tailoring": [
                         "Glycosylation"
@@ -224,12 +207,10 @@
                 },
                 {
                     "id": "WP_031147038.1",
-                    "name": "No gene ID",
                     "product": " 2-oxoglutarate and non-heme iron family"
                 },
                 {
                     "id": "WP_051892707.1",
-                    "name": "No gene ID",
                     "product": "cytocrome P450-like",
                     "tailoring": [
                         "Glycosylation"
@@ -237,7 +218,6 @@
                 },
                 {
                     "id": "WP_031147042.1",
-                    "name": "No gene ID",
                     "product": "glycosyltransferase",
                     "tailoring": [
                         "Glycosylation"
@@ -245,32 +225,26 @@
                 },
                 {
                     "id": "WP_031147044.1",
-                    "name": "No gene ID",
                     "product": "putative O-methyltransferase"
                 },
                 {
                     "id": "WP_051892708.1",
-                    "name": "No gene ID",
                     "product": "DUF418"
                 },
                 {
                     "id": "WP_031147048.1",
-                    "name": "No gene ID",
                     "product": "15-methyltransferase"
                 },
                 {
                     "id": "WP_031147050.1",
-                    "name": "No gene ID",
                     "product": "3,5-epimerase"
                 },
                 {
                     "id": "WP_037631640.1",
-                    "name": "No gene ID",
                     "product": "2,3-dehydratase"
                 },
                 {
                     "id": "WP_051892710.1",
-                    "name": "No gene ID",
                     "product": "SARP family"
                 }
             ]

--- a/data/BGC0001852.json
+++ b/data/BGC0001852.json
@@ -11,7 +11,8 @@
         },
         {
             "comments": [
-                "Removed gene names of 'No gene ID'"
+                "Removed gene names of 'No gene ID'",
+                "Removed gene annotation with no information"
             ],
             "contributors": [
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
@@ -52,10 +53,6 @@
                 {
                     "id": "WP_030957326.1",
                     "product": "2nd and 3rd ring cyclase"
-                },
-                {
-                    "id": "WP_030957328.1",
-                    "name": "No gene ID"
                 },
                 {
                     "id": "WP_030957329.1",

--- a/data/BGC0001852.json
+++ b/data/BGC0001852.json
@@ -70,10 +70,6 @@
                     "product": "aminomethylase"
                 },
                 {
-                    "id": "WP_078906285.1",
-                    "name": "No gene ID"
-                },
-                {
                     "id": "WP_030957336.1",
                     "product": "3-methyltransferase"
                 },
@@ -98,10 +94,6 @@
                 {
                     "id": "WP_030957343.1",
                     "product": "4,6-dehydratase"
-                },
-                {
-                    "id": "WP_030957345.1",
-                    "name": "No gene ID"
                 },
                 {
                     "functions": [
@@ -132,10 +124,6 @@
                     "tailoring": [
                         "Demethylation"
                     ]
-                },
-                {
-                    "id": "WP_030957350.1",
-                    "name": "No gene ID"
                 },
                 {
                     "id": "WP_030957351.1",
@@ -180,16 +168,8 @@
                     ]
                 },
                 {
-                    "id": "WP_107056739.1",
-                    "name": "No gene ID"
-                },
-                {
                     "id": "WP_030957368.1",
                     "product": "ABC transporter"
-                },
-                {
-                    "id": "WP_030957370.1",
-                    "name": "No gene ID"
                 },
                 {
                     "id": "WP_030957371.1",

--- a/data/BGC0001852.json
+++ b/data/BGC0001852.json
@@ -8,6 +8,15 @@
                 "K5UBFDWZSYOHS4HI42NVQMJK"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Removed gene names of 'No gene ID'"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -30,22 +39,18 @@
             "annotations": [
                 {
                     "id": "WP_030957320.1",
-                    "name": "No gene ID",
                     "product": "3-ketoreductase"
                 },
                 {
                     "id": "WP_030957322.1",
-                    "name": "No gene ID",
                     "product": "aminotransferase"
                 },
                 {
                     "id": "WP_030957324.1",
-                    "name": "No gene ID",
                     "product": "aminomethylase"
                 },
                 {
                     "id": "WP_030957326.1",
-                    "name": "No gene ID",
                     "product": "2nd and 3rd ring cyclase"
                 },
                 {
@@ -54,17 +59,14 @@
                 },
                 {
                     "id": "WP_030957329.1",
-                    "name": "No gene ID",
                     "product": "4-ketoreductase"
                 },
                 {
                     "id": "WP_030957330.1",
-                    "name": "No gene ID",
                     "product": "acyl carrier protein"
                 },
                 {
                     "id": "WP_030957332.1",
-                    "name": "No gene ID",
                     "product": "aminomethylase"
                 },
                 {
@@ -73,12 +75,10 @@
                 },
                 {
                     "id": "WP_030957336.1",
-                    "name": "No gene ID",
                     "product": "3-methyltransferase"
                 },
                 {
                     "id": "WP_030957338.1",
-                    "name": "No gene ID",
                     "product": "glycosyltransferase",
                     "tailoring": [
                         "Glycosylation"
@@ -86,12 +86,10 @@
                 },
                 {
                     "id": "WP_030957340.1",
-                    "name": "No gene ID",
                     "product": "oxidase"
                 },
                 {
                     "id": "WP_030957341.1",
-                    "name": "No gene ID",
                     "product": "glycosyltransferase",
                     "tailoring": [
                         "Glycosylation"
@@ -99,7 +97,6 @@
                 },
                 {
                     "id": "WP_030957343.1",
-                    "name": "No gene ID",
                     "product": "4,6-dehydratase"
                 },
                 {
@@ -116,7 +113,6 @@
                         }
                     ],
                     "id": "WP_078906300.1",
-                    "name": "No gene ID",
                     "product": "10-decarboxylase",
                     "tailoring": [
                         "Decarboxylation"
@@ -132,7 +128,6 @@
                         }
                     ],
                     "id": "WP_030957349.1",
-                    "name": "No gene ID",
                     "product": "15-methylesterase",
                     "tailoring": [
                         "Demethylation"
@@ -144,37 +139,30 @@
                 },
                 {
                     "id": "WP_030957351.1",
-                    "name": "No gene ID",
                     "product": "4th ring cyclase"
                 },
                 {
                     "id": "WP_030957352.1",
-                    "name": "No gene ID",
                     "product": "monooxygenase"
                 },
                 {
                     "id": "WP_030957354.1",
-                    "name": "No gene ID",
                     "product": "ketosynthase α-subunit"
                 },
                 {
                     "id": "WP_030957356.1",
-                    "name": "No gene ID",
                     "product": "ketosynthase β-subunit"
                 },
                 {
                     "id": "WP_030957358.1",
-                    "name": "No gene ID",
                     "product": "9-ketoreductase"
                 },
                 {
                     "id": "WP_030957360.1",
-                    "name": "No gene ID",
                     "product": "aromatase"
                 },
                 {
                     "id": "WP_030957361.1",
-                    "name": "No gene ID",
                     "product": "glycosyltransferase",
                     "tailoring": [
                         "Glycosylation"
@@ -182,12 +170,10 @@
                 },
                 {
                     "id": "WP_051808697.1",
-                    "name": "No gene ID",
                     "product": "7-ketoreductase"
                 },
                 {
                     "id": "WP_030957364.1",
-                    "name": "No gene ID",
                     "product": "P450-like",
                     "tailoring": [
                         "Glycosylation"
@@ -199,7 +185,6 @@
                 },
                 {
                     "id": "WP_030957368.1",
-                    "name": "No gene ID",
                     "product": "ABC transporter"
                 },
                 {
@@ -208,7 +193,6 @@
                 },
                 {
                     "id": "WP_030957371.1",
-                    "name": "No gene ID",
                     "product": "glycosyltransferase",
                     "tailoring": [
                         "Glycosylation"
@@ -216,7 +200,6 @@
                 },
                 {
                     "id": "WP_030957372.1",
-                    "name": "No gene ID",
                     "product": "11-hydroxylase",
                     "tailoring": [
                         "Glycosylation"
@@ -224,12 +207,10 @@
                 },
                 {
                     "id": "WP_030957374.1",
-                    "name": "No gene ID",
                     "product": " 2-oxoglutarate and non-heme iron family"
                 },
                 {
                     "id": "WP_051808699.1",
-                    "name": "No gene ID",
                     "product": "cytocrome P450-like",
                     "tailoring": [
                         "Glycosylation"
@@ -237,7 +218,6 @@
                 },
                 {
                     "id": "WP_030957378.1",
-                    "name": "No gene ID",
                     "product": "glycosyltransferase",
                     "tailoring": [
                         "Glycosylation"
@@ -245,32 +225,26 @@
                 },
                 {
                     "id": "WP_030957379.1",
-                    "name": "No gene ID",
                     "product": "putative O-methyltransferase"
                 },
                 {
                     "id": "WP_051808700.1",
-                    "name": "No gene ID",
                     "product": "DUF418"
                 },
                 {
                     "id": "WP_030957381.1",
-                    "name": "No gene ID",
                     "product": "15-methyltransferase"
                 },
                 {
                     "id": "WP_030957384.1",
-                    "name": "No gene ID",
                     "product": "3,5-epimerase"
                 },
                 {
                     "id": "WP_037878726.1",
-                    "name": "No gene ID",
                     "product": "2,3-dehydratase"
                 },
                 {
                     "id": "WP_078906286.1",
-                    "name": "No gene ID",
                     "product": "SARP family"
                 }
             ]

--- a/data/BGC0001857.json
+++ b/data/BGC0001857.json
@@ -8,6 +8,15 @@
                 "VI2SAJFMVVIEGOHMYZDSD4C4"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Removed gene names of 'No gene ID'"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -49,7 +58,6 @@
                         }
                     ],
                     "id": "QBE85641.1",
-                    "name": "No gene ID",
                     "product": "BuaB"
                 },
                 {
@@ -62,7 +70,6 @@
                         }
                     ],
                     "id": "QBE85642.1",
-                    "name": "No gene ID",
                     "product": "BuaC"
                 },
                 {
@@ -75,7 +82,6 @@
                         }
                     ],
                     "id": "QBE85643.1",
-                    "name": "No gene ID",
                     "product": "BuaD",
                     "tailoring": [
                         "Hydroxylation"
@@ -91,7 +97,6 @@
                         }
                     ],
                     "id": "QBE85644.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
@@ -104,7 +109,6 @@
                         }
                     ],
                     "id": "QBE85645.1",
-                    "name": "No gene ID",
                     "product": "BuaE"
                 },
                 {
@@ -117,7 +121,6 @@
                         }
                     ],
                     "id": "QBE85646.1",
-                    "name": "No gene ID",
                     "product": "BuaF"
                 },
                 {
@@ -130,7 +133,6 @@
                         }
                     ],
                     "id": "QBE85647.1",
-                    "name": "No gene ID",
                     "product": "BuaG",
                     "tailoring": [
                         "Hydroxylation"
@@ -146,7 +148,6 @@
                         }
                     ],
                     "id": "QBE85648.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
@@ -159,7 +160,6 @@
                         }
                     ],
                     "id": "QBE85649.1",
-                    "name": "No gene ID",
                     "product": "BuaA"
                 }
             ],

--- a/data/BGC0001859.json
+++ b/data/BGC0001859.json
@@ -11,7 +11,8 @@
         },
         {
             "comments": [
-                "Fetch compound properties from PubChem"
+                "Fetch compound properties from PubChem",
+                "Removed gene names of 'No gene ID'"
             ],
             "contributors": [
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
@@ -61,7 +62,6 @@
                         }
                     ],
                     "id": "AFM38982.1",
-                    "name": "No gene ID",
                     "product": "F1 5,10-methylene-tetrahydrofolate dehydrogenase/cyclohydrolase"
                 },
                 {
@@ -74,7 +74,6 @@
                         }
                     ],
                     "id": "AFM38983.1",
-                    "name": "No gene ID",
                     "product": "MFS family transporter"
                 },
                 {
@@ -87,7 +86,6 @@
                         }
                     ],
                     "id": "AFM38984.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
@@ -100,7 +98,6 @@
                         }
                     ],
                     "id": "AFM38985.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
@@ -222,7 +219,6 @@
                 },
                 {
                     "id": "AFM38995.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 }
             ]

--- a/data/BGC0001865.json
+++ b/data/BGC0001865.json
@@ -8,6 +8,15 @@
                 "SP3TSEAU4FOO7XSAAVENWCIW"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Removed gene names of 'No gene ID'"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -49,32 +58,26 @@
                 },
                 {
                     "id": "XP_001798911.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
                     "id": "XP_001798912.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
                     "id": "XP_001798913.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
                     "id": "XP_001798914.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
                     "id": "XP_001798915.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
                     "id": "XP_001798916.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {

--- a/data/BGC0002055.json
+++ b/data/BGC0002055.json
@@ -11,7 +11,8 @@
         },
         {
             "comments": [
-                "Removed gene annotations with no information"
+                "Removed gene annotations with no information",
+                "Removed additional gene with no identifier or information"
             ],
             "contributors": [
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
@@ -305,18 +306,6 @@
                             {
                                 "end": 54614,
                                 "start": 53595
-                            }
-                        ],
-                        "strand": -1
-                    }
-                },
-                {
-                    "id": "No gene ID",
-                    "location": {
-                        "exons": [
-                            {
-                                "end": 54874,
-                                "start": 54692
                             }
                         ],
                         "strand": -1

--- a/data/BGC0002055.json
+++ b/data/BGC0002055.json
@@ -8,6 +8,15 @@
                 "DSCNCSJNYVZZHSG74Z2O37QE"
             ],
             "version": "2.1"
+        },
+        {
+            "comments": [
+                "Removed gene annotations with no information"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -94,40 +103,6 @@
                     ]
                 },
                 {
-                    "functions": [
-                        {
-                            "category": "Unknown",
-                            "evidence": [
-                                "Sequence-based prediction"
-                            ]
-                        }
-                    ],
-                    "id": "mycK2",
-                    "name": "mycK2",
-                    "product": "Unknown"
-                },
-                {
-                    "functions": [
-                        {
-                            "category": "Unknown",
-                            "evidence": [
-                                "Sequence-based prediction"
-                            ]
-                        }
-                    ],
-                    "id": "No gene ID",
-                    "name": "No gene ID",
-                    "product": "Unknown"
-                },
-                {
-                    "functions": [
-                        {
-                            "category": "Unknown",
-                            "evidence": [
-                                "Sequence-based prediction"
-                            ]
-                        }
-                    ],
                     "id": "mycT",
                     "name": "mycT",
                     "product": "di-oxygenase"
@@ -147,19 +122,6 @@
                     "tailoring": [
                         "Methylation"
                     ]
-                },
-                {
-                    "functions": [
-                        {
-                            "category": "Unknown",
-                            "evidence": [
-                                "Sequence-based prediction"
-                            ]
-                        }
-                    ],
-                    "id": "mycK1",
-                    "name": "mycK1",
-                    "product": "Unknown"
                 },
                 {
                     "functions": [
@@ -191,43 +153,9 @@
                     "product": "polyketide synthase"
                 },
                 {
-                    "functions": [
-                        {
-                            "category": "Unknown",
-                            "evidence": [
-                                "Sequence-based prediction"
-                            ]
-                        }
-                    ],
                     "id": "mycB",
                     "name": "mycB",
                     "product": "enoyl reductase"
-                },
-                {
-                    "functions": [
-                        {
-                            "category": "Unknown",
-                            "evidence": [
-                                "Sequence-based prediction"
-                            ]
-                        }
-                    ],
-                    "id": "No gene ID",
-                    "name": "No gene ID",
-                    "product": "Unknown"
-                },
-                {
-                    "functions": [
-                        {
-                            "category": "Unknown",
-                            "evidence": [
-                                "Sequence-based prediction"
-                            ]
-                        }
-                    ],
-                    "id": "No gene ID",
-                    "name": "No gene ID",
-                    "product": "Unknown"
                 },
                 {
                     "functions": [
@@ -245,32 +173,6 @@
                 {
                     "functions": [
                         {
-                            "category": "Unknown",
-                            "evidence": [
-                                "Sequence-based prediction"
-                            ]
-                        }
-                    ],
-                    "id": "mycS",
-                    "name": "mycS",
-                    "product": "Unknown"
-                },
-                {
-                    "functions": [
-                        {
-                            "category": "Unknown",
-                            "evidence": [
-                                "Sequence-based prediction"
-                            ]
-                        }
-                    ],
-                    "id": "No gene ID",
-                    "name": "No gene ID",
-                    "product": "Unknown"
-                },
-                {
-                    "functions": [
-                        {
                             "category": "Transport",
                             "evidence": [
                                 "Sequence-based prediction"
@@ -280,19 +182,6 @@
                     "id": "mycR",
                     "name": "mycR",
                     "product": "transporter"
-                },
-                {
-                    "functions": [
-                        {
-                            "category": "Unknown",
-                            "evidence": [
-                                "Sequence-based prediction"
-                            ]
-                        }
-                    ],
-                    "id": "mycQ",
-                    "name": "mycQ",
-                    "product": "Unknown"
                 },
                 {
                     "functions": [

--- a/pending/BGC0002042.json
+++ b/pending/BGC0002042.json
@@ -3,7 +3,8 @@
         {
             "comments": [
                 "Submitted",
-                "Corrected NRP module activity"
+                "Corrected NRP module activity",
+                "Corrected gene identifiers"
             ],
             "contributors": [
                 "P34OM6JOCMMIEQMA65E4OI3N",
@@ -108,7 +109,7 @@
                             "QEG98944.1",
                             "QEG98945.1",
                             "QEG98946.1",
-                            "eg98947.1",
+                            "QEG98947.1",
                             "QEG98948.1",
                             "QEG98952.1"
                         ]
@@ -279,8 +280,8 @@
                         }
                     ],
                     "id": "QEG98944.1",
-                    "name": "ant10",
-                    "product": "Ant9"
+                    "name": "ant9",
+                    "product": "ant9"
                 },
                 {
                     "functions": [

--- a/pending/BGC0002049.json
+++ b/pending/BGC0002049.json
@@ -2,10 +2,12 @@
     "changelog": [
         {
             "comments": [
-                "Submitted"
+                "Submitted",
+                "Removed gene names of 'No gene ID'"
             ],
             "contributors": [
-                "KTTDKEJDYAQ7MKSNPMBDOYYX"
+                "KTTDKEJDYAQ7MKSNPMBDOYYX",
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.1"
         }
@@ -92,7 +94,6 @@
                         }
                     ],
                     "id": "WP_083782369.1",
-                    "name": "No gene ID",
                     "product": "microviridin/marinostatin family tricyclic proteinase inhibitor"
                 },
                 {
@@ -105,7 +106,6 @@
                         }
                     ],
                     "id": "WP_012408791.1",
-                    "name": "No gene ID",
                     "product": "MvdC family ATP-grasp ribosomal peptide maturase",
                     "tailoring": [
                         "Heterocyclization"
@@ -121,7 +121,6 @@
                         }
                     ],
                     "id": "WP_041565327.1",
-                    "name": "No gene ID",
                     "product": "MvdD family ATP-grasp ribosomal peptide maturase",
                     "tailoring": [
                         "Heterocyclization"
@@ -129,12 +128,10 @@
                 },
                 {
                     "id": "WP_012408793.1",
-                    "name": "No gene ID",
                     "product": "patatin"
                 },
                 {
                     "id": "WP_012408794.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
@@ -147,7 +144,6 @@
                         }
                     ],
                     "id": "WP_012408795.1",
-                    "name": "No gene ID",
                     "product": "ABC transporter ATP-binding protein/permease"
                 }
             ]

--- a/pending/BGC0002050.json
+++ b/pending/BGC0002050.json
@@ -4,7 +4,8 @@
             "comments": [
                 "Submitted",
                 "Corrected NRP module activity",
-                "Removed erroneous gene name"
+                "Removed erroneous gene name",
+                "Removed gene annotations with no information"
             ],
             "contributors": [
                 "Z7AIIJAM3U3HR6IYDPQOINM4",
@@ -53,14 +54,6 @@
                     ]
                 },
                 {
-                    "functions": [
-                        {
-                            "category": "Unknown",
-                            "evidence": [
-                                "Sequence-based prediction"
-                            ]
-                        }
-                    ],
                     "id": "QIE07360.1",
                     "product": "hypothetical protein"
                 },

--- a/pending/BGC0002050.json
+++ b/pending/BGC0002050.json
@@ -3,7 +3,8 @@
         {
             "comments": [
                 "Submitted",
-                "Corrected NRP module activity"
+                "Corrected NRP module activity",
+                "Removed erroneous gene name"
             ],
             "contributors": [
                 "Z7AIIJAM3U3HR6IYDPQOINM4",
@@ -61,7 +62,6 @@
                         }
                     ],
                     "id": "QIE07360.1",
-                    "name": "necB",
                     "product": "hypothetical protein"
                 },
                 {

--- a/pending/BGC0002061.json
+++ b/pending/BGC0002061.json
@@ -4,7 +4,8 @@
             "comments": [
                 "Submitted",
                 "Corrected NRP module activity",
-                "Removed gene names of 'No gene ID'"
+                "Removed gene names of 'No gene ID'",
+                "Corrected duplicate gene name"
             ],
             "contributors": [
                 "KTTDKEJDYAQ7MKSNPMBDOYYX",
@@ -104,7 +105,6 @@
                         }
                     ],
                     "id": "WP_012408788.1",
-                    "name": "proC",
                     "product": "zinc-binding dehydrogenase"
                 },
                 {

--- a/pending/BGC0002061.json
+++ b/pending/BGC0002061.json
@@ -3,7 +3,8 @@
         {
             "comments": [
                 "Submitted",
-                "Corrected NRP module activity"
+                "Corrected NRP module activity",
+                "Removed gene names of 'No gene ID'"
             ],
             "contributors": [
                 "KTTDKEJDYAQ7MKSNPMBDOYYX",
@@ -43,7 +44,6 @@
                         }
                     ],
                     "id": "WP_012408783.1",
-                    "name": "No gene ID",
                     "product": "non-ribosomal peptide synthetase"
                 },
                 {
@@ -56,7 +56,6 @@
                         }
                     ],
                     "id": "WP_148220293.1",
-                    "name": "No gene ID",
                     "product": "acyltransferase domain-containing protein"
                 },
                 {
@@ -69,7 +68,6 @@
                         }
                     ],
                     "id": "WP_012408785.1",
-                    "name": "No gene ID",
                     "product": "non-ribosomal peptide synthetase"
                 },
                 {
@@ -82,7 +80,6 @@
                         }
                     ],
                     "id": "WP_012408786.1",
-                    "name": "No gene ID",
                     "product": "non-ribosomal peptide synthetase"
                 },
                 {
@@ -95,7 +92,6 @@
                         }
                     ],
                     "id": "WP_012408787.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
@@ -134,7 +130,6 @@
                         }
                     ],
                     "id": "WP_012408790.1",
-                    "name": "No gene ID",
                     "product": "ABC transporter ATP-binding protein/permease"
                 }
             ]

--- a/pending/BGC0002066.json
+++ b/pending/BGC0002066.json
@@ -3,7 +3,8 @@
         {
             "comments": [
                 "Submitted",
-                "Corrected NRP module activity"
+                "Corrected NRP module activity",
+                "Removed gene names of 'No gene ID'"
             ],
             "contributors": [
                 "PAM2M7KUAUIJ3CVOXWVXWGKQ",
@@ -48,7 +49,6 @@
             "annotations": [
                 {
                     "id": "KKP04592.1",
-                    "name": "No gene ID",
                     "product": "Transcription factor"
                 },
                 {
@@ -61,7 +61,6 @@
                         }
                     ],
                     "id": "KKP04593.1",
-                    "name": "No gene ID",
                     "product": "O-methyl transferase",
                     "tailoring": [
                         "Methylation"
@@ -77,7 +76,6 @@
                         }
                     ],
                     "id": "KKP04594.1",
-                    "name": "No gene ID",
                     "product": "Flavin-dependent monooxygenase",
                     "tailoring": [
                         "Hydroxylation"
@@ -93,7 +91,6 @@
                         }
                     ],
                     "id": "KKP04595.1",
-                    "name": "No gene ID",
                     "product": "cytochrome P450 monooxygenase",
                     "tailoring": [
                         "Hydroxylation"
@@ -109,7 +106,6 @@
                         }
                     ],
                     "id": "KKP04596.1",
-                    "name": "No gene ID",
                     "product": "trans enoyl-reductase"
                 },
                 {
@@ -122,7 +118,6 @@
                         }
                     ],
                     "id": "KKP04597.1",
-                    "name": "No gene ID",
                     "product": "Flavin-dependent monooxygenase"
                 },
                 {
@@ -135,7 +130,6 @@
                         }
                     ],
                     "id": "KKP04598.1",
-                    "name": "No gene ID",
                     "product": "cytochrome P450 monooxygenase"
                 },
                 {
@@ -148,17 +142,14 @@
                         }
                     ],
                     "id": "KKP04599.1",
-                    "name": "No gene ID",
                     "product": "Non-ribosomal peptide synthetase - Polyketide synthase"
                 },
                 {
                     "id": "KKP04600.1",
-                    "name": "No gene ID",
                     "product": "Transcription factor"
                 },
                 {
                     "id": "KKP04601.1",
-                    "name": "No gene ID",
                     "product": "major facilitator superfamily transporter"
                 }
             ]

--- a/pending/BGC0002067.json
+++ b/pending/BGC0002067.json
@@ -3,7 +3,8 @@
         {
             "comments": [
                 "Submitted",
-                "Corrected NRP module activity"
+                "Corrected NRP module activity",
+                "Removed gene names of 'No gene ID'"
             ],
             "contributors": [
                 "PAM2M7KUAUIJ3CVOXWVXWGKQ",
@@ -48,12 +49,10 @@
             "annotations": [
                 {
                     "id": "EPS34228.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
                     "id": "EPS34229.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
@@ -66,7 +65,6 @@
                         }
                     ],
                     "id": "EPS34230.1",
-                    "name": "No gene ID",
                     "product": "flavin-dependent monooxygenase",
                     "tailoring": [
                         "Hydroxylation"
@@ -74,7 +72,6 @@
                 },
                 {
                     "id": "EPS34231.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
@@ -87,7 +84,6 @@
                         }
                     ],
                     "id": "EPS34232.1",
-                    "name": "No gene ID",
                     "product": "o-methyl transferase",
                     "tailoring": [
                         "Methylation"
@@ -103,7 +99,6 @@
                         }
                     ],
                     "id": "EPS34233.1",
-                    "name": "No gene ID",
                     "product": "transcription factor"
                 },
                 {
@@ -116,7 +111,6 @@
                         }
                     ],
                     "id": "EPS34234.1",
-                    "name": "No gene ID",
                     "product": "nonribosomal peptide synthatase-polyketide synthase"
                 },
                 {
@@ -129,7 +123,6 @@
                         }
                     ],
                     "id": "EPS34235.1",
-                    "name": "No gene ID",
                     "product": "cytochrome P450 monooxygenase"
                 },
                 {
@@ -142,7 +135,6 @@
                         }
                     ],
                     "id": "EPS34236.1",
-                    "name": "No gene ID",
                     "product": "flavin-dependent monooxygenase"
                 },
                 {
@@ -155,7 +147,6 @@
                         }
                     ],
                     "id": "EPS34237.1",
-                    "name": "No gene ID",
                     "product": "trans-enoyl reductase"
                 },
                 {
@@ -168,7 +159,6 @@
                         }
                     ],
                     "id": "EPS34238.1",
-                    "name": "No gene ID",
                     "product": "cytochrome P450 monooxygenase",
                     "tailoring": [
                         "Hydroxylation"

--- a/pending/BGC0002075.json
+++ b/pending/BGC0002075.json
@@ -3,7 +3,8 @@
         {
             "comments": [
                 "Submitted",
-                "Corrected NRP module activity"
+                "Corrected NRP module activity",
+                "Removed gene names of 'No gene ID'"
             ],
             "contributors": [
                 "6CADHILFODRMCII55WHSHZ6V",
@@ -113,7 +114,6 @@
                         }
                     ],
                     "id": "WP_064118616.1",
-                    "name": "No gene ID",
                     "product": "non-ribosomal peptide synthetase"
                 }
             ]

--- a/pending/BGC0002080.json
+++ b/pending/BGC0002080.json
@@ -2,10 +2,12 @@
     "changelog": [
         {
             "comments": [
-                "Submitted"
+                "Submitted",
+                "Removed gene names of 'No gene ID'"
             ],
             "contributors": [
-                "FF3ZPRRW73UWTQ65BL4APVC7"
+                "FF3ZPRRW73UWTQ65BL4APVC7",
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.1"
         }
@@ -77,7 +79,6 @@
                         }
                     ],
                     "id": "QEF99665.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
@@ -90,7 +91,6 @@
                         }
                     ],
                     "id": "QEF99668.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
@@ -103,7 +103,6 @@
                         }
                     ],
                     "id": "QEF99671.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
@@ -116,7 +115,6 @@
                         }
                     ],
                     "id": "QEF99672.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 },
                 {
@@ -129,7 +127,6 @@
                         }
                     ],
                     "id": "QEF99677.1",
-                    "name": "No gene ID",
                     "product": "hypothetical protein"
                 }
             ]

--- a/pending/BGC0002080.json
+++ b/pending/BGC0002080.json
@@ -3,7 +3,8 @@
         {
             "comments": [
                 "Submitted",
-                "Removed gene names of 'No gene ID'"
+                "Removed gene names of 'No gene ID'",
+                "Fixed duplicate gene name"
             ],
             "contributors": [
                 "FF3ZPRRW73UWTQ65BL4APVC7",
@@ -40,7 +41,6 @@
                         }
                     ],
                     "id": "QEF99658.1",
-                    "name": "dnrK",
                     "product": "Fatty acid desaturase"
                 },
                 {

--- a/schema.json
+++ b/schema.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$schema_created": "2020-01-21T15:40:24+02:00",
-    "$schema_version": "2.2",
+    "$schema_created": "2022-05-17T13:40:24+02:00",
+    "$schema_version": "2.3",
     "additionalProperties": false,
     "properties": {
         "changelog": {
@@ -264,6 +264,7 @@
                                         "type": "array"
                                     },
                                     "id": {
+                                        "pattern": "^[^ ].*[^ ]$",
                                         "title": "Gene ID",
                                         "type": "string"
                                     },
@@ -272,6 +273,7 @@
                                         "type": "string"
                                     },
                                     "name": {
+                                        "pattern": "^[^ ].*[^ ]$",
                                         "title": "Gene name, ",
                                         "type": "string"
                                     },
@@ -308,6 +310,7 @@
                                 "additionalProperties": false,
                                 "properties": {
                                     "id": {
+                                        "pattern": "^[^ ].*[^ ]$",
                                         "title": "Gene ID",
                                         "type": "string"
                                     },
@@ -723,6 +726,7 @@
                                 "properties": {
                                     "genes": {
                                         "items": {
+                                            "pattern": "^[^,]*$",
                                             "type": "string"
                                         },
                                         "minItems": 1,
@@ -747,6 +751,7 @@
                                             },
                                             "genes": {
                                                 "items": {
+                                                    "pattern": "^[^,]*$",
                                                     "type": "string"
                                                 },
                                                 "minItems": 1,
@@ -807,10 +812,11 @@
                                                 },
                                                 "genes": {
                                                     "items": {
+                                                        "pattern": "^[^,]*$",
                                                         "type": "string"
                                                     },
                                                     "minItems": 1,
-                                                    "title": "all genes forming the synthase",
+                                                    "title": "all genes forming the module",
                                                     "type": "array"
                                                 },
                                                 "kr_stereochem": {

--- a/scripts/check_valid.py
+++ b/scripts/check_valid.py
@@ -4,7 +4,7 @@ import glob
 import json
 import os
 import sys
-from typing import List
+from typing import Any, Dict, List
 
 from jsonschema import validate, ValidationError
 
@@ -12,21 +12,44 @@ with open("schema.json") as schema_handle:
     schema = json.load(schema_handle)
 
 
+def check_gene_duplication(data: Dict[str, Any], prefix: str) -> bool:
+    ids = []
+    names = []
+    for gene in data["cluster"].get("genes", {}).get("annotations", {}):
+        ids.append(gene["id"])
+        name = gene.get("name")
+        if name:
+            names.append(name)
+    id_mismatch = len(set(ids)) != len(ids)
+    name_mismatch = len(set(names)) != len(names)
+    if id_mismatch or name_mismatch:
+        message_chunks = []
+        if id_mismatch:
+            message_chunks.append("ids")
+        if id_mismatch and name_mismatch:
+            message_chunks.append("and")
+        if name_mismatch:
+            message_chunks.append("names")
+        print(f"{prefix}{' '.join(message_chunks)} duplicated in gene annotations")
+        return False
+    return True
+
+
 def check_all() -> bool:
     valid = True
     for dir_name in ["data", "pending"]:
-        valid = check_multiple(glob.glob(os.path.join(dir_name, "*.json"))) and valid
+        valid = check_multiple(glob.glob(os.path.join(dir_name, "*.json")), prefix=f"{dir_name}/") and valid
     return valid
 
 
-def check_multiple(files: List[str]) -> bool:
+def check_multiple(files: List[str], prefix: str = "") -> bool:
     valid = True
-    for file in files:
-        valid = check_single(file) and valid
+    for file in sorted(files):
+        valid = check_single(file, prefix=prefix) and valid
     return valid
 
 
-def check_single(file: str) -> bool:
+def check_single(file: str, prefix: str = "") -> bool:
     with open(file) as handle:
         try:
             data = json.load(handle)
@@ -39,7 +62,19 @@ def check_single(file: str) -> bool:
         lines = str(err).splitlines()
         print(f"{os.path.split(file)[-1]}: {lines[-2]} {lines[0]}")
         return False
-    return True
+
+    valid = True
+
+    if prefix:
+        prefix = f"{prefix}{file.rsplit(prefix, 1)[-1]}: "
+    try:
+        for func in [
+            check_gene_duplication,
+        ]:
+            valid = func(data, prefix) and valid
+    except KeyError as err:
+        raise ValueError(f"missing expected field in {prefix}: {err}") from err
+    return valid
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Removes all `No gene ID` identifiers, replacing them with valid identifiers if possible or removing the fields if not.

Removes or corrects all duplications of genes in gene annotations, as the identifier should be unique, The validator script should now prevent new cases of this appearing.

Corrected, and forbidden in the schema for future cases, any gene identifiers containing trailing or leading whitespace.

Fixes a batch of entries where the polyketide module gene list was a single string containing comma separated gene names instead of being an actual list of strings. The schema has changed to forbid commas in any gene names in that list. Commas remain in the gene annotations `name` field for some entries, but will be handled later on.