### PR TITLE
Fix NRPS module activity

### DIFF
--- a/data/BGC0000150.json
+++ b/data/BGC0000150.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -60,7 +69,7 @@
                     "gene_id": "ABP55165.1",
                     "modules": [
                         {
-                            "active": true,
+                            "active": false,
                             "c_dom_subtype": "LCL",
                             "module_number": "2"
                         }

--- a/data/BGC0000186.json
+++ b/data/BGC0000186.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -120,7 +129,7 @@
                                     "D-alanine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "4"
                         }

--- a/data/BGC0000289.json
+++ b/data/BGC0000289.json
@@ -17,6 +17,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -667,7 +676,7 @@
                                     "Hydroxyphenylglycine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "module_number": "1"
                         },
                         {
@@ -680,7 +689,7 @@
                                     "Tyrosine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "2"
                         }
@@ -699,7 +708,7 @@
                                     "3,5-Dihydroxyphenylglycine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "3"
                         }
@@ -718,7 +727,7 @@
                                     "Hydroxyphenylglycine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "4"
                         },
@@ -732,7 +741,7 @@
                                     "Hydroxyphenylglycine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "5"
                         },
@@ -746,7 +755,7 @@
                                     "Tyrosine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "6"
                         }
@@ -765,7 +774,7 @@
                                     "3,5-Dihydroxyphenylglycine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "modification_domains": [
                                 "Unknown"

--- a/data/BGC0000290.json
+++ b/data/BGC0000290.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -90,7 +99,7 @@
                                     "4-Hydroxyphenylglycine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "1"
                         },
@@ -104,7 +113,7 @@
                                     "Tyrosine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "2"
                         }
@@ -130,7 +139,7 @@
                                     "3,5-Dihydroxy-phenylglycine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "3"
                         }
@@ -155,7 +164,7 @@
                                     "4-Hydroxyphenylglycine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "4"
                         },
@@ -175,7 +184,7 @@
                                     "4-Hydroxyphenylglycine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "5"
                         },
@@ -192,7 +201,7 @@
                                     "Tyrosine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "6"
                         }
@@ -218,7 +227,7 @@
                                     "3,5-Dihydroxy-phenylglycine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "7"
                         }

--- a/data/BGC0000298.json
+++ b/data/BGC0000298.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -167,7 +176,7 @@
                     "gene_id": "ACM68682.1",
                     "modules": [
                         {
-                            "active": false,
+                            "active": true,
                             "modification_domains": [
                                 "Keto reductase"
                             ],
@@ -188,7 +197,7 @@
                                     "Isoleucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "1"
                         }
@@ -210,7 +219,7 @@
                                     "2-carboxy-6-hydroxyoctahydroindole"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "2"
                         }
@@ -220,7 +229,7 @@
                     "gene_id": "ACM68691.1",
                     "modules": [
                         {
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "3"
                         }

--- a/data/BGC0000302.json
+++ b/data/BGC0000302.json
@@ -17,6 +17,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -70,7 +79,7 @@
                                     "Arginine / Lysine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "module_number": "A0"
                         },
                         {
@@ -83,7 +92,7 @@
                                     "Lysine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "A1"
                         }
@@ -102,7 +111,7 @@
                                     "Tyrosine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "module_number": "B0"
                         },
                         {
@@ -115,7 +124,7 @@
                                     "Lysine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "B1"
                         }
@@ -134,7 +143,7 @@
                                     "Valine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "2"
                         }
@@ -153,7 +162,7 @@
                                     "Homotyrosine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "3"
                         },
@@ -164,7 +173,7 @@
                                     "N-Methyl-alanine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "modification_domains": [
                                 "Methylation"
@@ -186,7 +195,7 @@
                                     "Phenylalanine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "5"
                         }

--- a/data/BGC0000305.json
+++ b/data/BGC0000305.json
@@ -17,6 +17,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -137,7 +146,7 @@
                                     "Threonine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "3"
                         },
@@ -151,7 +160,7 @@
                                     "Leucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "4"
                         },
@@ -165,7 +174,7 @@
                                     "Leucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "5"
                         },
@@ -179,7 +188,7 @@
                                     "Serine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "6"
                         }
@@ -198,7 +207,7 @@
                                     "Leucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "7"
                         },
@@ -212,7 +221,7 @@
                                     "Serine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "8"
                         },
@@ -226,7 +235,7 @@
                                     "Isoleucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "9"
                         },
@@ -240,7 +249,7 @@
                                     "Isoleucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "10"
                         },
@@ -254,7 +263,7 @@
                                     "Aspartate"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "11"
                         }

--- a/data/BGC0000306.json
+++ b/data/BGC0000306.json
@@ -17,6 +17,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -71,7 +80,7 @@
                                     "Serine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Starter",
                             "modification_domains": [
                                 "Methylation"
@@ -88,7 +97,7 @@
                                     "Alanine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "2"
                         }
@@ -107,7 +116,7 @@
                                     "Glycine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "module_number": "2"
                         },
                         {
@@ -120,7 +129,7 @@
                                     "4-Hydroxyphenylglycine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "modification_domains": [
                                 "Methylation"
@@ -137,7 +146,7 @@
                                     "Alanine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "4"
                         },
@@ -151,7 +160,7 @@
                                     "Tyrosine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "5"
                         }

--- a/data/BGC0000314.json
+++ b/data/BGC0000314.json
@@ -20,10 +20,12 @@
         },
         {
             "comments": [
-                "Update NCBI taxid after old taxid was merged"
+                "Update NCBI taxid after old taxid was merged",
+                "Corrected NRP module activity"
             ],
             "contributors": [
-                "3UOU7PODQJXIM6BEPUHHRRA5"
+                "3UOU7PODQJXIM6BEPUHHRRA5",
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.1"
         }
@@ -75,7 +77,7 @@
                                     "Coumaric acid"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "module_number": "A0"
                         }
                     ]
@@ -93,7 +95,7 @@
                                     "Threonine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "B1"
                         }
@@ -112,7 +114,7 @@
                                     "Valine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "B2"
                         },
@@ -126,7 +128,7 @@
                                     "Asparagine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "B3"
                         }
@@ -145,7 +147,7 @@
                                     "Asparagine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "B4"
                         },
@@ -159,7 +161,7 @@
                                     "Isoleucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "B5"
                         }

--- a/data/BGC0000315.json
+++ b/data/BGC0000315.json
@@ -30,10 +30,12 @@
         },
         {
             "comments": [
-                "Fix duplication in gene evidence (issue #1)"
+                "Fix duplication in gene evidence (issue #1)",
+                "Corrected NRP module activity"
             ],
             "contributors": [
-                "3UOU7PODQJXIM6BEPUHHRRA5"
+                "3UOU7PODQJXIM6BEPUHHRRA5",
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.1"
         }
@@ -554,7 +556,7 @@
                                     "Serine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Starter",
                             "module_number": "1"
                         },
@@ -568,7 +570,7 @@
                                     "Threonine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "2"
                         },
@@ -582,7 +584,7 @@
                                     "Tryptophan"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "3"
                         },
@@ -596,7 +598,7 @@
                                     "Aspartate"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "4"
                         },
@@ -610,7 +612,7 @@
                                     "Aspartate"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "5"
                         },
@@ -624,7 +626,7 @@
                                     "4-Hydroxyphenylglycine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "6"
                         }
@@ -640,7 +642,7 @@
                                     "Aspartate"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "7"
                         },
@@ -654,7 +656,7 @@
                                     "Glycine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "8"
                         },
@@ -668,7 +670,7 @@
                                     "Asparigine or (2S, 3S)-3-hydroxyasparagine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "9"
                         }
@@ -684,7 +686,7 @@
                                     "Glutamate or (2S, 3R)-3-methylglutamate"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "10"
                         },
@@ -698,7 +700,7 @@
                                     "Tryptophan"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "11"
                         }

--- a/data/BGC0000319.json
+++ b/data/BGC0000319.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -89,7 +98,7 @@
                                     "2-Amino-adipic-acid"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "module_number": "0"
                         },
                         {
@@ -102,7 +111,7 @@
                                     "Cysteine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "1"
                         },
@@ -116,7 +125,7 @@
                                     "Valine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "2"
                         }

--- a/data/BGC0000320.json
+++ b/data/BGC0000320.json
@@ -19,6 +19,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -158,7 +167,7 @@
                             }
                         },
                         {
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "2"
                         }

--- a/data/BGC0000323.json
+++ b/data/BGC0000323.json
@@ -17,6 +17,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -150,7 +159,7 @@
                                     "Leucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Starter",
                             "module_number": "1"
                         },
@@ -164,7 +173,7 @@
                                     "Leucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "2"
                         },
@@ -178,7 +187,7 @@
                                     "Glutamine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "3"
                         }
@@ -194,7 +203,7 @@
                                     "Leucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "4"
                         },
@@ -208,7 +217,7 @@
                                     "Glutamine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "5"
                         },
@@ -219,7 +228,7 @@
                                     "Valine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "6"
                         },
@@ -233,7 +242,7 @@
                                     "Leucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "7"
                         },
@@ -244,7 +253,7 @@
                                     "Leucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "8"
                         }

--- a/data/BGC0000330.json
+++ b/data/BGC0000330.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -302,7 +311,7 @@
                     "gene_id": "CAJ96472.1",
                     "modules": [
                         {
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Starter",
                             "modification_domains": [
                                 "Oxidation"
@@ -319,7 +328,7 @@
                                     "Aspartate"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "modification_domains": [
                                 "Oxidation"
@@ -336,7 +345,7 @@
                                     "2,4-Diaminobutyric acid"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "modification_domains": [
                                 "Oxidation"
@@ -358,7 +367,7 @@
                                     "Aspartate"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "3"
                         }
@@ -377,7 +386,7 @@
                                     "Glycine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "4"
                         }
@@ -396,7 +405,7 @@
                                     "N5-Hydroxyornithine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "5"
                         }

--- a/data/BGC0000333.json
+++ b/data/BGC0000333.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -78,7 +87,7 @@
                                     "2-Amino-3,5-dimethyl-4-hexenoic Acid"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "7"
                         },
@@ -89,7 +98,7 @@
                                     "Leucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "6"
                         },

--- a/data/BGC0000345.json
+++ b/data/BGC0000345.json
@@ -17,6 +17,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -231,7 +240,7 @@
                                     "Leucine"
                                 ]
                             },
-                            "active": false
+                            "active": true
                         }
                     ]
                 },
@@ -248,7 +257,7 @@
                                     "Serine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "1"
                         },
@@ -259,7 +268,7 @@
                                     "Leucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "2"
                         }

--- a/data/BGC0000346.json
+++ b/data/BGC0000346.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -117,7 +126,7 @@
                                     "Isoleucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Starter",
                             "modification_domains": [
                                 "Methylation"
@@ -134,7 +143,7 @@
                                     "Isoleucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "2"
                         },
@@ -148,7 +157,7 @@
                                     "Threonine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "3"
                         },
@@ -159,7 +168,7 @@
                                     "Leucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "4"
                         }

--- a/data/BGC0000350.json
+++ b/data/BGC0000350.json
@@ -17,6 +17,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -157,7 +166,7 @@
                                     "Glycolic acid"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "2"
                         },
@@ -171,7 +180,7 @@
                                     "Alanine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "3"
                         }

--- a/data/BGC0000352.json
+++ b/data/BGC0000352.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -135,7 +144,7 @@
                     "gene_id": "ACIAD2773",
                     "modules": [
                         {
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Heterocyclization",
                             "modification_domains": [
                                 "Unknown"
@@ -152,7 +161,7 @@
                                     "Serine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "2"
                         },
@@ -166,7 +175,7 @@
                                     "Serine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "3"
                         }

--- a/data/BGC0000355.json
+++ b/data/BGC0000355.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -181,7 +190,7 @@
                                     "Anthranilate"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "1"
                         },
@@ -195,7 +204,7 @@
                                     "Tryptophan"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "2"
                         },
@@ -209,7 +218,7 @@
                                     "Alanine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Heterocyclization",
                             "module_number": "3"
                         }
@@ -228,7 +237,7 @@
                                     "Alanine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Heterocyclization",
                             "module_number": "1"
                         }

--- a/data/BGC0000356.json
+++ b/data/BGC0000356.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -312,7 +321,7 @@
                                     "Proline"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "1"
                         },
@@ -327,7 +336,7 @@
                                     "Proline"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "2"
                         }

--- a/data/BGC0000357.json
+++ b/data/BGC0000357.json
@@ -17,6 +17,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -190,7 +199,7 @@
                                     "Phenylalanine, Tyrosine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "module_number": "0"
                         },
                         {
@@ -203,7 +212,7 @@
                                     "(Phenylalanine, Tryptophane),(Valine, Isoleucine)"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "1"
                         },
@@ -217,17 +226,17 @@
                                     "Valine, isoleucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "2"
                         },
                         {
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "3"
                         },
                         {
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "4"
                         }

--- a/data/BGC0000361.json
+++ b/data/BGC0000361.json
@@ -22,7 +22,8 @@
         },
         {
             "comments": [
-                "Add additional reference"
+                "Add additional reference",
+                "Corrected NRP module activity"
             ],
             "contributors": [
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
@@ -138,7 +139,7 @@
                                     "Phenylalanine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "module_number": "0"
                         },
                         {
@@ -151,12 +152,12 @@
                                     "Serine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "1"
                         },
                         {
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "2"
                         }

--- a/data/BGC0000369.json
+++ b/data/BGC0000369.json
@@ -20,10 +20,12 @@
         },
         {
             "comments": [
-                "Remove negative molecular mass"
+                "Remove negative molecular mass",
+                "Corrected NRP module activity"
             ],
             "contributors": [
-                "3UOU7PODQJXIM6BEPUHHRRA5"
+                "3UOU7PODQJXIM6BEPUHHRRA5",
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.1"
         }
@@ -72,7 +74,7 @@
                                     "Dihydroxy hexadecanoic acid"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "module_number": "0"
                         }
                     ]
@@ -90,7 +92,7 @@
                                     "Threonine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "3"
                         },
@@ -104,7 +106,7 @@
                                     "Tyrosine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "4"
                         }
@@ -123,7 +125,7 @@
                                     "Threonine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "5"
                         },
@@ -137,7 +139,7 @@
                                     "Glutamine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "6"
                         },
@@ -151,7 +153,7 @@
                                     "Glycine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "7"
                         }
@@ -170,7 +172,7 @@
                                     "Threonine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Starter",
                             "module_number": "1"
                         },
@@ -184,7 +186,7 @@
                                     "Threonine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "2"
                         }
@@ -203,7 +205,7 @@
                                     "N-methyl-threonine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "modification_domains": [
                                 "Methylation"
@@ -220,7 +222,7 @@
                                     "Glutamine / Tyrosine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "9"
                         }

--- a/data/BGC0000372.json
+++ b/data/BGC0000372.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -216,7 +225,7 @@
                                     "Tryptophan"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "1"
                         },
@@ -230,7 +239,7 @@
                                     "Alanine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Heterocyclization",
                             "module_number": "2"
                         }

--- a/data/BGC0000374.json
+++ b/data/BGC0000374.json
@@ -17,6 +17,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -595,7 +604,7 @@
                     "gene_id": "AEH41790.1",
                     "modules": [
                         {
-                            "active": false,
+                            "active": true,
                             "module_number": "0"
                         }
                     ]
@@ -613,7 +622,7 @@
                                     "(3-Ncp)Ala"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "1"
                         },
@@ -627,7 +636,7 @@
                                     "Threonine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "2"
                         },
@@ -641,7 +650,7 @@
                                     "(beta-Me)Phe"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "3"
                         },
@@ -655,7 +664,7 @@
                                     "(3-Ncp)Ala"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "4"
                         }
@@ -674,7 +683,7 @@
                                     "(beta-Me)Phe"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "5"
                         },
@@ -688,7 +697,7 @@
                                     "Valine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "comments": "both the activity assay and the nonribosomal code for HrmP2A suggest that Val is incorporated into hormaomycin although Ile is the amino acid present in hormaomycin.",
                             "module_number": "6"
@@ -703,7 +712,7 @@
                                     "(4-Pe)Pro"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "7"
                         }

--- a/data/BGC0000380.json
+++ b/data/BGC0000380.json
@@ -17,6 +17,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -303,7 +312,7 @@
                                     "Cysteine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Heterocyclization",
                             "module_number": "1"
                         }
@@ -322,7 +331,7 @@
                                     "Proline"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "6"
                         }

--- a/data/BGC0000383.json
+++ b/data/BGC0000383.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -93,7 +102,7 @@
                                     "Threonine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Starter",
                             "module_number": "1"
                         }
@@ -112,7 +121,7 @@
                                     "Lysine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "2"
                         },
@@ -126,7 +135,7 @@
                                     "Alanine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "3"
                         }

--- a/data/BGC0000386.json
+++ b/data/BGC0000386.json
@@ -21,7 +21,8 @@
         },
         {
             "comments": [
-                "Fix incorrect accession"
+                "Fix incorrect accession",
+                "Corrected NRP module activity"
             ],
             "contributors": [
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
@@ -100,7 +101,7 @@
                                     "N5-Hydroxyornithine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "1"
                         },
@@ -114,7 +115,7 @@
                                     "Aspartate"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "modification_domains": [
                                 "beta-hydroxylation"
@@ -128,7 +129,7 @@
                                     "Serine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "3"
                         }
@@ -138,7 +139,7 @@
                     "gene_id": "ABC37099",
                     "modules": [
                         {
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "3"
                         },
@@ -149,7 +150,7 @@
                                     "N5-hydroxy-N5-formylornitine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "4"
                         }

--- a/data/BGC0000389.json
+++ b/data/BGC0000389.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -109,7 +118,7 @@
                                     "Leucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "A1"
                         },
@@ -123,7 +132,7 @@
                                     "Glutamate"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "A2"
                         }
@@ -142,7 +151,7 @@
                                     "Threonine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "B1"
                         },
@@ -156,7 +165,7 @@
                                     "Isoleucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "B2"
                         },
@@ -184,7 +193,7 @@
                                     "Serine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "B4"
                         }
@@ -203,7 +212,7 @@
                                     "Leucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "B5"
                         },
@@ -231,7 +240,7 @@
                                     "Isoleucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "B7"
                         }

--- a/data/BGC0000393.json
+++ b/data/BGC0000393.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -72,7 +81,7 @@
                     "gene_id": "MXAN_3779",
                     "modules": [
                         {
-                            "active": true,
+                            "active": false,
                             "c_dom_subtype": "Unknown",
                             "module_number": "0",
                             "non_canonical": {
@@ -94,7 +103,7 @@
                                     "Serine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "modification_domains": [
                                 "Methylation"
@@ -111,7 +120,7 @@
                                     "Leucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "2"
                         },
@@ -125,7 +134,7 @@
                                     "bOH-Val"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "3"
                         },
@@ -139,7 +148,7 @@
                                     "Serine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "4"
                         },
@@ -153,7 +162,7 @@
                                     "Valine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "5"
                         },
@@ -200,7 +209,7 @@
                             "module_number": "10"
                         },
                         {
-                            "active": true,
+                            "active": false,
                             "c_dom_subtype": "LCL",
                             "module_number": "11",
                             "non_canonical": {
@@ -222,7 +231,7 @@
                                     "Alanine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "12"
                         }

--- a/data/BGC0000398.json
+++ b/data/BGC0000398.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -155,7 +164,7 @@
                                     "Leucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Starter",
                             "module_number": "A1"
                         },
@@ -169,7 +178,7 @@
                                     "Glutamate"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "A2"
                         }
@@ -188,7 +197,7 @@
                                     "Threonine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "B1"
                         },
@@ -202,7 +211,7 @@
                                     "Valine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "B2"
                         },
@@ -216,7 +225,7 @@
                                     "Leucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "B3"
                         },
@@ -230,7 +239,7 @@
                                     "Serine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "B4"
                         }
@@ -249,7 +258,7 @@
                                     "Serine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "C3"
                         },
@@ -291,7 +300,7 @@
                                     "Valine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "C4"
                         }

--- a/data/BGC0000399.json
+++ b/data/BGC0000399.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -89,7 +98,7 @@
                                     "Leucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Starter",
                             "module_number": "1"
                         },
@@ -103,7 +112,7 @@
                                     "Glutamate"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "2"
                         }
@@ -122,7 +131,7 @@
                                     "Threonine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "3"
                         },
@@ -136,7 +145,7 @@
                                     "Isoleucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "4"
                         },
@@ -150,7 +159,7 @@
                                     "Leucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "5"
                         },
@@ -164,7 +173,7 @@
                                     "Serine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "6"
                         }
@@ -183,7 +192,7 @@
                                     "Leucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "7"
                         },
@@ -197,7 +206,7 @@
                                     "Leucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "8"
                         },
@@ -211,7 +220,7 @@
                                     "Serine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "9"
                         },
@@ -225,7 +234,7 @@
                                     "Valine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "10"
                         }

--- a/data/BGC0000405.json
+++ b/data/BGC0000405.json
@@ -17,6 +17,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -174,7 +183,7 @@
                                     "2-Amino-adipic-acid"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "module_number": "0"
                         },
                         {
@@ -187,7 +196,7 @@
                                     "Cysteine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "1"
                         },
@@ -201,7 +210,7 @@
                                     "Valine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "2"
                         }

--- a/data/BGC0000416.json
+++ b/data/BGC0000416.json
@@ -17,6 +17,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -84,7 +93,7 @@
                                     "Leucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "modification_domains": [
                                 "Methylation"
@@ -136,7 +145,7 @@
                                     "Valine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "modification_domains": [
                                 "Methylation"
@@ -144,7 +153,7 @@
                             "module_number": "3"
                         },
                         {
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "4"
                         }

--- a/data/BGC0000419.json
+++ b/data/BGC0000419.json
@@ -17,6 +17,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -524,7 +533,7 @@
                                     "Hydroxyphenylglycine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "1"
                         },
@@ -538,7 +547,7 @@
                                     "Beta-hydroxytyrosine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "module_number": "2"
                         }
                     ]
@@ -547,7 +556,7 @@
                     "gene_id": "AIG79242.1",
                     "modules": [
                         {
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "2"
                         },
@@ -561,7 +570,7 @@
                                     "3,5-Dihydroxyphenylglycine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "module_number": "3"
                         }
                     ]
@@ -570,7 +579,7 @@
                     "gene_id": "AIG79241.1",
                     "modules": [
                         {
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "3"
                         },
@@ -584,7 +593,7 @@
                                     "4-Hydroxyphenylglycine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "4"
                         },
@@ -598,7 +607,7 @@
                                     "4-Hydroxyphenylglycine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "5"
                         },
@@ -612,7 +621,7 @@
                                     "Beta-hydroxytyrosine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "module_number": "6"
                         }
                     ]
@@ -621,7 +630,7 @@
                     "gene_id": "AIG79240.1",
                     "modules": [
                         {
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "6"
                         },
@@ -635,7 +644,7 @@
                                     "3,5-Dihydroxyphenylglycine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "7"
                         }

--- a/data/BGC0000420.json
+++ b/data/BGC0000420.json
@@ -19,6 +19,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -256,7 +265,7 @@
                                     "Tryptophan"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "module_number": "0"
                         },
                         {
@@ -269,12 +278,12 @@
                                     "Histidine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "1"
                         },
                         {
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "2"
                         }

--- a/data/BGC0000424.json
+++ b/data/BGC0000424.json
@@ -17,6 +17,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -198,7 +207,7 @@
                                     "Aspartate"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "1"
                         },
@@ -212,7 +221,7 @@
                                     "Serine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "2"
                         },
@@ -226,7 +235,7 @@
                                     "Aspartate"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "modification_domains": [
                                 "Hydroxylation"
@@ -243,7 +252,7 @@
                                     "Threonine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "4"
                         },
@@ -257,7 +266,7 @@
                                     "Serine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "5"
                         },
@@ -274,7 +283,7 @@
                                     "N5-Hydroxyornithine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "6"
                         }

--- a/data/BGC0000425.json
+++ b/data/BGC0000425.json
@@ -17,6 +17,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -170,7 +179,7 @@
                                     "2,3-Dehydro-2-aminobutyric acid"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Starter",
                             "module_number": "1"
                         },
@@ -184,7 +193,7 @@
                                     "D-proline"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "2"
                         },
@@ -198,7 +207,7 @@
                                     "D-serine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "3"
                         },
@@ -212,7 +221,7 @@
                                     "D-leucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "4"
                         },
@@ -226,7 +235,7 @@
                                     "D-valine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "5"
                         },
@@ -240,7 +249,7 @@
                                     "D-glutamine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "6"
                         }
@@ -259,7 +268,7 @@
                                     "D-glutamine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "10"
                         },
@@ -273,7 +282,7 @@
                                     "Leucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "11"
                         },
@@ -287,7 +296,7 @@
                                     "D-valine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "12"
                         },
@@ -301,7 +310,7 @@
                                     "D-leucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "7"
                         },
@@ -315,7 +324,7 @@
                                     "D-valine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "8"
                         },
@@ -329,7 +338,7 @@
                                     "Valine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "9"
                         }
@@ -348,7 +357,7 @@
                                     "2,3-Dehydro-2-aminobutyric acid"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "13"
                         },
@@ -362,7 +371,7 @@
                                     "D-allothreonine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "14"
                         },
@@ -376,7 +385,7 @@
                                     "Isoleucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "15"
                         },
@@ -390,7 +399,7 @@
                                     "Homoserine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "16"
                         },
@@ -404,7 +413,7 @@
                                     "2,4-Diaminobutyric acid"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "17"
                         },
@@ -418,7 +427,7 @@
                                     "Lysine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "18"
                         }

--- a/data/BGC0000426.json
+++ b/data/BGC0000426.json
@@ -17,6 +17,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -91,7 +100,7 @@
                                     "Phenylalanine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "module_number": "1"
                         }
                     ]
@@ -109,7 +118,7 @@
                                     "Alanine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "2"
                         },
@@ -123,7 +132,7 @@
                                     "Tryptophan"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "3"
                         }

--- a/data/BGC0000427.json
+++ b/data/BGC0000427.json
@@ -17,6 +17,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -85,7 +94,7 @@
                                     "Serine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "module_number": "0"
                         }
                     ]

--- a/data/BGC0000429.json
+++ b/data/BGC0000429.json
@@ -22,7 +22,8 @@
         },
         {
             "comments": [
-                "Manually updates compound information for skyllamycin A & B (Structure from Pubchem isn't correct)"
+                "Manually updates compound information for skyllamycin A & B (Structure from Pubchem isn't correct)",
+                "Corrected NRP module activity"
             ],
             "contributors": [
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
@@ -737,7 +738,7 @@
                                     "Threonine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Starter",
                             "module_number": "1"
                         },
@@ -751,7 +752,7 @@
                                     "Alanine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "2"
                         },
@@ -765,7 +766,7 @@
                                     "Beta-methoxyaspartate"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "3"
                         },
@@ -779,7 +780,7 @@
                                     "Glycine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "4"
                         }
@@ -798,7 +799,7 @@
                                     "Phenylalanine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "modification_domains": [
                                 "Oxidation"
@@ -815,7 +816,7 @@
                                     "Proline"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "6"
                         },
@@ -829,7 +830,7 @@
                                     "Tyrosine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "modification_domains": [
                                 "Oxidation"
@@ -846,7 +847,7 @@
                                     "D-tryptophan"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "8"
                         }
@@ -865,7 +866,7 @@
                                     "D-leucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "10"
                         },
@@ -879,7 +880,7 @@
                                     "D-leucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "modification_domains": [
                                 "Oxidation"
@@ -896,7 +897,7 @@
                                     "Glycine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "9"
                         }

--- a/data/BGC0000430.json
+++ b/data/BGC0000430.json
@@ -17,6 +17,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -98,7 +107,7 @@
                                     "Homotyrosine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "1"
                         },
@@ -112,7 +121,7 @@
                                     "Proline"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "2"
                         },
@@ -126,7 +135,7 @@
                                     "Argininal"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "modification_domains": [
                                 "Unknown"

--- a/data/BGC0000431.json
+++ b/data/BGC0000431.json
@@ -20,10 +20,12 @@
         },
         {
             "comments": [
-                "Remove negative molecular mass"
+                "Remove negative molecular mass",
+                "Corrected NRP module activity"
             ],
             "contributors": [
-                "3UOU7PODQJXIM6BEPUHHRRA5"
+                "3UOU7PODQJXIM6BEPUHHRRA5",
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.1"
         }
@@ -68,7 +70,7 @@
                                     "Cysteic acid"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "module_number": "0"
                         }
                     ]
@@ -86,7 +88,7 @@
                                     "Threonine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Starter",
                             "module_number": "1"
                         },
@@ -100,7 +102,7 @@
                                     "Serine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "2"
                         },
@@ -114,12 +116,12 @@
                                     "2,3-Diaminopropionic acid"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "3"
                         },
                         {
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "4"
                         },
@@ -133,7 +135,7 @@
                                     "Threonine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "5"
                         },
@@ -147,7 +149,7 @@
                                     "Valine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "6"
                         }
@@ -166,7 +168,7 @@
                                     "Serine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "7"
                         },
@@ -180,7 +182,7 @@
                                     "Lysine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "8"
                         },
@@ -194,7 +196,7 @@
                                     "Glycine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "modification_domains": [
                                 "Methylation"

--- a/data/BGC0000433.json
+++ b/data/BGC0000433.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -186,7 +195,7 @@
                                     "Glutamate"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "1"
                         },
@@ -200,7 +209,7 @@
                                     "Leucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "2"
                         },
@@ -214,7 +223,7 @@
                                     "Leucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "3"
                         }
@@ -233,7 +242,7 @@
                                     "Valine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "4"
                         },
@@ -247,7 +256,7 @@
                                     "Aspartate"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "5"
                         },
@@ -261,7 +270,7 @@
                                     "Leucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "6"
                         }
@@ -280,7 +289,7 @@
                                     "Leucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "modification_domains": [
                                 "Unknown"

--- a/data/BGC0000440.json
+++ b/data/BGC0000440.json
@@ -17,6 +17,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -609,7 +618,7 @@
                                     "Hydroxyphenylglycine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "module_number": "1"
                         },
                         {
@@ -622,7 +631,7 @@
                                     "Tyrosine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "2"
                         }
@@ -641,7 +650,7 @@
                                     "3,5-Dihydroxyphenylglycine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "3"
                         }
@@ -660,7 +669,7 @@
                                     "Hydroxyphenylglycine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "4"
                         },
@@ -674,7 +683,7 @@
                                     "Hydroxyphenylglycine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "5"
                         },
@@ -688,7 +697,7 @@
                                     "Tyrosine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "6"
                         }
@@ -707,7 +716,7 @@
                                     "3,5-Dihydroxyphenylglycine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "modification_domains": [
                                 "Unknown"

--- a/data/BGC0000442.json
+++ b/data/BGC0000442.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -71,7 +80,7 @@
                                     "Indole pyruvic acid"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "module_number": "1"
                         }
                     ]

--- a/data/BGC0000443.json
+++ b/data/BGC0000443.json
@@ -19,6 +19,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -71,7 +80,7 @@
                                     "Serine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "1"
                         },
@@ -85,7 +94,7 @@
                                     "Ornithine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "2"
                         },
@@ -99,7 +108,7 @@
                                     "Aspartate"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "3"
                         },
@@ -113,7 +122,7 @@
                                     "Lysine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "4"
                         },
@@ -127,7 +136,7 @@
                                     "Histidine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "5"
                         }
@@ -146,7 +155,7 @@
                                     "Threonine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "6"
                         },
@@ -160,7 +169,7 @@
                                     "Didehydroaminobutyric acid"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "7"
                         },
@@ -174,7 +183,7 @@
                                     "Hydroxyaspartate"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "8"
                         },
@@ -188,7 +197,7 @@
                                     "4-Chlorothreonine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "modification_domains": [
                                 "Unknown"
@@ -210,7 +219,7 @@
                                     "Threonine"
                                 ]
                             },
-                            "active": true,
+                            "active": false,
                             "module_number": "10",
                             "non_canonical": {
                                 "evidence": [

--- a/data/BGC0000446.json
+++ b/data/BGC0000446.json
@@ -17,6 +17,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -129,7 +138,7 @@
                                     "2,3-Dihydroxybenzoic acid"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "module_number": "0"
                         }
                     ]
@@ -147,7 +156,7 @@
                                     "Proline"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "1"
                         }

--- a/data/BGC0000447.json
+++ b/data/BGC0000447.json
@@ -17,6 +17,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -91,7 +100,7 @@
                                     "Threonine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Starter",
                             "modification_domains": [
                                 "dehydration"
@@ -108,7 +117,7 @@
                                     "Proline"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "2"
                         },
@@ -122,7 +131,7 @@
                                     "Serine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "3"
                         }
@@ -141,7 +150,7 @@
                                     "Leucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "4"
                         },
@@ -155,7 +164,7 @@
                                     "Valine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "5"
                         },
@@ -169,7 +178,7 @@
                                     "Serine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "6"
                         }
@@ -188,7 +197,7 @@
                                     "Leucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "7"
                         },
@@ -202,7 +211,7 @@
                                     "Valine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "8"
                         },
@@ -216,7 +225,7 @@
                                     "Valine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "9"
                         }
@@ -235,7 +244,7 @@
                                     "Glutamine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "10"
                         },
@@ -249,7 +258,7 @@
                                     "Leucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "11"
                         },
@@ -263,7 +272,7 @@
                                     "Valine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "12"
                         }
@@ -282,7 +291,7 @@
                                     "Threonine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "modification_domains": [
                                 "dehydration"
@@ -299,7 +308,7 @@
                                     "Threonine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "14"
                         },
@@ -313,7 +322,7 @@
                                     "Leucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "15"
                         },
@@ -327,7 +336,7 @@
                                     "Homoserine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "16"
                         },
@@ -341,7 +350,7 @@
                                     "2,4-Diaminobutyric acid"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "17"
                         },
@@ -355,7 +364,7 @@
                                     "Lysine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "18"
                         }

--- a/data/BGC0000459.json
+++ b/data/BGC0000459.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -524,7 +533,7 @@
                                     "3-hydroxypicolinic acid"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "module_number": "0"
                         }
                     ]
@@ -542,7 +551,7 @@
                                     "Threonine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "1"
                         },
@@ -556,7 +565,7 @@
                                     "Leucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "2"
                         }
@@ -575,7 +584,7 @@
                                     "4-Hydroxyproline"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "A3"
                         }
@@ -594,7 +603,7 @@
                                     "Sarcosine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "modification_domains": [
                                 "Methylation"
@@ -611,7 +620,7 @@
                                     "Beta-methylleucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "modification_domains": [
                                 "Methylation"
@@ -628,7 +637,7 @@
                                     "Alanine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "6"
                         },
@@ -642,7 +651,7 @@
                                     "Phenylglycine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "modification_domains": [
                                 "Methylation"
@@ -664,7 +673,7 @@
                                     "Glycine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "B3"
                         }
@@ -683,7 +692,7 @@
                                     "Serine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "modification_domains": [
                                 "Unknown"
                             ],
@@ -704,7 +713,7 @@
                                     "Cysteine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "module_number": "B9"
                         }
                     ]
@@ -713,12 +722,12 @@
                     "gene_id": "AGN74896.1",
                     "modules": [
                         {
-                            "active": true,
+                            "active": false,
                             "c_dom_subtype": "Unknown",
                             "module_number": "B10"
                         },
                         {
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "9"
                         }

--- a/data/BGC0000463.json
+++ b/data/BGC0000463.json
@@ -17,6 +17,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -141,7 +150,7 @@
                                     "Leucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Starter",
                             "module_number": "1"
                         },
@@ -155,7 +164,7 @@
                                     "Glutamate"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "2"
                         }
@@ -174,7 +183,7 @@
                                     "Glutamine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "10"
                         },
@@ -188,7 +197,7 @@
                                     "Glutamine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "3"
                         },
@@ -202,7 +211,7 @@
                                     "Valine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "4"
                         },
@@ -216,7 +225,7 @@
                                     "Leucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "5"
                         },
@@ -230,7 +239,7 @@
                                     "Glutamine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "6"
                         },
@@ -244,7 +253,7 @@
                                     "Serine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "7"
                         },
@@ -258,7 +267,7 @@
                                     "Valine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "8"
                         },
@@ -272,7 +281,7 @@
                                     "Leucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "9"
                         }
@@ -291,7 +300,7 @@
                                     "Leucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "11"
                         },
@@ -305,7 +314,7 @@
                                     "Leucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "12"
                         },
@@ -319,7 +328,7 @@
                                     "Glutamine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "13"
                         },
@@ -333,7 +342,7 @@
                                     "Isoleucine; Valine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "14"
                         }

--- a/data/BGC0000464.json
+++ b/data/BGC0000464.json
@@ -17,6 +17,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -78,7 +87,7 @@
                     "gene_id": "XDD1_2281",
                     "modules": [
                         {
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "1"
                         }
@@ -88,16 +97,16 @@
                     "gene_id": "XDD1_2282",
                     "modules": [
                         {
-                            "active": false,
+                            "active": true,
                             "module_number": "2"
                         },
                         {
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "3"
                         },
                         {
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "4"
                         },
@@ -107,12 +116,12 @@
                             "module_number": "5"
                         },
                         {
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "6"
                         },
                         {
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "7"
                         }
@@ -122,12 +131,12 @@
                     "gene_id": "XDD1_2283",
                     "modules": [
                         {
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "8"
                         },
                         {
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "9"
                         }
@@ -137,7 +146,7 @@
                     "gene_id": "XDD1_2287",
                     "modules": [
                         {
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "10"
                         },

--- a/data/BGC0000816.json
+++ b/data/BGC0000816.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -177,7 +186,7 @@
                                     "Proline"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "module_number": "0"
                         },
                         {
@@ -190,7 +199,7 @@
                                     "Tryptophan"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "1"
                         }

--- a/data/BGC0000818.json
+++ b/data/BGC0000818.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -64,7 +73,7 @@
                                     "Proline"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "1"
                         },
@@ -78,7 +87,7 @@
                                     "Tryptophan"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "2"
                         }

--- a/data/BGC0000819.json
+++ b/data/BGC0000819.json
@@ -21,7 +21,8 @@
         },
         {
             "comments": [
-                "Add additional reference"
+                "Add additional reference",
+                "Corrected NRP module activity"
             ],
             "contributors": [
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
@@ -74,7 +75,7 @@
                                     "4-Methylproline"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "1"
                         },
@@ -88,7 +89,7 @@
                                     "Tryptophan"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "modification_domains": [
                                 "Unknown"
                             ],

--- a/data/BGC0000921.json
+++ b/data/BGC0000921.json
@@ -17,6 +17,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -231,7 +240,7 @@
                                     "Proline"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "module_number": "0"
                         }
                     ]

--- a/data/BGC0000950.json
+++ b/data/BGC0000950.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -521,7 +530,7 @@
                     "gene_id": "ADY76660.1",
                     "modules": [
                         {
-                            "active": false
+                            "active": true
                         }
                     ]
                 },
@@ -529,7 +538,7 @@
                     "gene_id": "ADY76661.1",
                     "modules": [
                         {
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL"
                         }
                     ]
@@ -547,7 +556,7 @@
                                     "m-Tyrosine"
                                 ]
                             },
-                            "active": false
+                            "active": true
                         }
                     ]
                 },
@@ -555,7 +564,7 @@
                     "gene_id": "ADY76666.1",
                     "modules": [
                         {
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL"
                         }
                     ]
@@ -573,7 +582,7 @@
                                     "(2S,3S)-2,3-Diaminobutyric acid"
                                 ]
                             },
-                            "active": false
+                            "active": true
                         }
                     ]
                 },
@@ -590,7 +599,7 @@
                                     "m-Tyrosine"
                                 ]
                             },
-                            "active": false
+                            "active": true
                         }
                     ]
                 },
@@ -598,7 +607,7 @@
                     "gene_id": "ADY76678.1",
                     "modules": [
                         {
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL"
                         }
                     ]
@@ -616,7 +625,7 @@
                                     "Methionine"
                                 ]
                             },
-                            "active": false
+                            "active": true
                         }
                     ]
                 }

--- a/data/BGC0000954.json
+++ b/data/BGC0000954.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -219,7 +228,7 @@
                                     "Serine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "8",
                             "non_canonical": {
@@ -243,7 +252,7 @@
                                     "N-Methyl-Glycine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "modification_domains": [
                                 "Methylation"

--- a/data/BGC0000955.json
+++ b/data/BGC0000955.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -171,7 +180,7 @@
                                     "Glycine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Starter",
                             "module_number": "0"
                         },
@@ -185,7 +194,7 @@
                                     "Cysteine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Heterocyclization",
                             "modification_domains": [
                                 "Oxidation"
@@ -207,7 +216,7 @@
                                     "Serine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "2"
                         },
@@ -221,7 +230,7 @@
                                     "Cysteine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Heterocyclization",
                             "modification_domains": [
                                 "Oxidation"
@@ -238,7 +247,7 @@
                                     "Glycine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "4"
                         }

--- a/data/BGC0000958.json
+++ b/data/BGC0000958.json
@@ -17,6 +17,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -91,7 +100,7 @@
                     "gene_id": "ZP_09179982.1",
                     "modules": [
                         {
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Starter",
                             "module_number": "0"
                         }
@@ -101,7 +110,7 @@
                     "gene_id": "ZP_09179983.1",
                     "modules": [
                         {
-                            "active": false,
+                            "active": true,
                             "module_number": "0"
                         }
                     ]
@@ -119,7 +128,7 @@
                                     "Threonine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Starter",
                             "module_number": "1"
                         },
@@ -133,7 +142,7 @@
                                     "Pyruvate"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "2"
                         }

--- a/data/BGC0000959.json
+++ b/data/BGC0000959.json
@@ -20,10 +20,12 @@
         },
         {
             "comments": [
-                "Add new compound: aspyridone B"
+                "Add new compound: aspyridone B",
+                "Corrected NRP module activity"
             ],
             "contributors": [
-                "H5KVDLSVQ3TJW7SKCDNBDEVC"
+                "H5KVDLSVQ3TJW7SKCDNBDEVC",
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.1"
         }
@@ -120,7 +122,7 @@
                                     "Tryptophan"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "1"
                         }

--- a/data/BGC0000962.json
+++ b/data/BGC0000962.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -53,14 +62,6 @@
             "cyclic": false,
             "nrps_genes": [
                 {
-                    "gene_id": "AAN32974.1",
-                    "modules": [
-                        {
-                            "active": false
-                        }
-                    ]
-                },
-                {
                     "gene_id": "AAN32977.1",
                     "modules": [
                         {
@@ -73,7 +74,7 @@
                                     "Leucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "module_number": "0"
                         }
                     ]
@@ -91,7 +92,7 @@
                                     "(4S)-5,5,5-trichloroleucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "module_number": "1"
                         }
                     ]
@@ -100,7 +101,7 @@
                     "gene_id": "AAN32979.1",
                     "modules": [
                         {
-                            "active": false,
+                            "active": true,
                             "modification_domains": [
                                 "Methylation"
                             ],
@@ -121,7 +122,7 @@
                                     "Phenylalanine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "modification_domains": [
                                 "Methylation"
@@ -138,7 +139,7 @@
                                     "Cysteine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "4"
                         }

--- a/data/BGC0000963.json
+++ b/data/BGC0000963.json
@@ -20,10 +20,12 @@
         },
         {
             "comments": [
-                "Linked new NPAtlas id for bleomycin (npatlas:20036)"
+                "Linked new NPAtlas id for bleomycin (npatlas:20036)",
+                "Corrected NRP module activity"
             ],
             "contributors": [
-                "H5KVDLSVQ3TJW7SKCDNBDEVC"
+                "H5KVDLSVQ3TJW7SKCDNBDEVC",
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.1"
         }
@@ -380,7 +382,7 @@
                                     "Histidine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "8"
                         },
@@ -394,7 +396,7 @@
                                     "Asparigine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "9"
                         }
@@ -413,7 +415,7 @@
                                     "Alanine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "7"
                         }
@@ -432,7 +434,7 @@
                                     "Threonine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "6"
                         }
@@ -451,7 +453,7 @@
                                     "Asparigine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "3"
                         },
@@ -465,12 +467,12 @@
                                     "Serine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "4"
                         },
                         {
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Starter",
                             "module_number": "5"
                         }
@@ -489,7 +491,7 @@
                                     "Asparigine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "3"
                         }
@@ -508,7 +510,7 @@
                                     "Cysteine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Heterocyclization",
                             "modification_domains": [
                                 "Oxidation"
@@ -525,7 +527,7 @@
                                     "Cysteine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "modification_domains": [
                                 "Unknown"
@@ -542,7 +544,7 @@
                                     "Beta-alanine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "2"
                         }

--- a/data/BGC0000964.json
+++ b/data/BGC0000964.json
@@ -20,10 +20,12 @@
         },
         {
             "comments": [
-                "Add new compound: burkholdac B"
+                "Add new compound: burkholdac B",
+                "Corrected NRP module activity"
             ],
             "contributors": [
-                "H5KVDLSVQ3TJW7SKCDNBDEVC"
+                "H5KVDLSVQ3TJW7SKCDNBDEVC",
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.1"
         }
@@ -96,7 +98,7 @@
                                     "Cysteine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Heterocyclization",
                             "module_number": "1"
                         }
@@ -115,7 +117,7 @@
                                     "Methionine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "4"
                         },
@@ -129,7 +131,7 @@
                                     "Cysteine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "5"
                         },
@@ -143,7 +145,7 @@
                                     "Isoleucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "6"
                         }
@@ -153,7 +155,7 @@
                     "gene_id": "ABC38000.1",
                     "modules": [
                         {
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "8"
                         }

--- a/data/BGC0000967.json
+++ b/data/BGC0000967.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -493,7 +502,7 @@
                                     "Serine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "modification_domains": [
                                 "Methylation"
                             ],
@@ -514,12 +523,12 @@
                                     "Glycine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "4"
                         },
                         {
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "modification_domains": [
                                 "Unknown"
@@ -541,7 +550,7 @@
                                     "Serine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "module_number": "8"
                         }
                     ]
@@ -559,7 +568,7 @@
                                     "Alanine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "29"
                         }
@@ -578,7 +587,7 @@
                                     "Serine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "33"
                         }

--- a/data/BGC0000968.json
+++ b/data/BGC0000968.json
@@ -21,7 +21,8 @@
         {
             "comments": [
                 "Change compound name chaetoglobosins -> chaetoglobosin A (npatlas:13078)",
-                "Added new compound: chaetoglobosin C (npatlas:17501)"
+                "Added new compound: chaetoglobosin C (npatlas:17501)",
+                "Corrected NRP module activity"
             ],
             "contributors": [
                 "AAAAAAAAAAAAAAAAAAAAAAAA",
@@ -102,7 +103,7 @@
                                     "Tryptophan"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "1"
                         }

--- a/data/BGC0000969.json
+++ b/data/BGC0000969.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -147,7 +156,7 @@
                                     "Alanine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "4"
                         }
@@ -166,7 +175,7 @@
                                     "Tryptophan"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "modification_domains": [
                                 "Methylation"
@@ -186,7 +195,7 @@
                                     "(R)-bTyr"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "6"
                         }

--- a/data/BGC0000970.json
+++ b/data/BGC0000970.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -220,7 +229,7 @@
                                     "Tyrosine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "7"
                         }

--- a/data/BGC0000971.json
+++ b/data/BGC0000971.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -238,7 +247,7 @@
                     "gene_id": "CBW54671.1",
                     "modules": [
                         {
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "2"
                         }
@@ -257,7 +266,7 @@
                                     "B-OH-cyc-hex-ala"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "2"
                         }

--- a/data/BGC0000972.json
+++ b/data/BGC0000972.json
@@ -17,6 +17,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -287,7 +296,7 @@
                                     "Alanine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "2"
                         }
@@ -306,10 +315,10 @@
                                     "Serine"
                                 ]
                             },
-                            "active": false
+                            "active": true
                         },
                         {
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL"
                         }
                     ]
@@ -327,7 +336,7 @@
                                     "Glycine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL"
                         },
                         {
@@ -340,7 +349,7 @@
                                     "Cysteine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Heterocyclization"
                         }
                     ]
@@ -358,7 +367,7 @@
                                     "Cysteine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Heterocyclization"
                         }
                     ]
@@ -376,7 +385,7 @@
                                     "Asparigine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Starter",
                             "module_number": "1"
                         }

--- a/data/BGC0000975.json
+++ b/data/BGC0000975.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -183,7 +192,7 @@
                                     "tyrosine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "modification_domains": [
                                 "Methylation"
@@ -205,7 +214,7 @@
                                     "methyl beta-alanine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "5"
                         },
@@ -219,7 +228,7 @@
                                     "alpha-ketoisocaproic acid"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "6"
                         }

--- a/data/BGC0000976.json
+++ b/data/BGC0000976.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -281,7 +290,7 @@
                                     "Cysteine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "4"
                         }

--- a/data/BGC0000978.json
+++ b/data/BGC0000978.json
@@ -17,6 +17,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -88,7 +97,7 @@
                                     "guanidinoacetate "
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "module_number": "0"
                         }
                     ]

--- a/data/BGC0000983.json
+++ b/data/BGC0000983.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -148,7 +157,7 @@
                                     "Phenylalanine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "2"
                         }

--- a/data/BGC0000996.json
+++ b/data/BGC0000996.json
@@ -22,10 +22,12 @@
             "comments": [
                 "Update compound structure (SMILES) for frontalamide B",
                 "Linked new PubChem id for frontalamide B (pubchem:101515038)",
-                "Add new compound: frontalamide A"
+                "Add new compound: frontalamide A",
+                "Corrected NRP module activity"
             ],
             "contributors": [
-                "5UL74VURKJ25VSPPPO3H2NYB"
+                "5UL74VURKJ25VSPPPO3H2NYB",
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.1"
         }
@@ -136,7 +138,7 @@
                                     "Ornithine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "1"
                         }

--- a/data/BGC0001000.json
+++ b/data/BGC0001000.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -177,7 +186,7 @@
                     "gene_id": "AAY42393.1",
                     "modules": [
                         {
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Starter",
                             "module_number": "0"
                         }
@@ -196,7 +205,7 @@
                                     "2-oxo-isovaleric acid"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "2"
                         },
@@ -210,7 +219,7 @@
                                     "Cysteine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Heterocyclization",
                             "modification_domains": [
                                 "Oxidation"
@@ -232,7 +241,7 @@
                                     "2-oxo-isovaleric acid"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "4"
                         },
@@ -246,7 +255,7 @@
                                     "Cysteine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Heterocyclization",
                             "modification_domains": [
                                 "Oxidation"

--- a/data/BGC0001003.json
+++ b/data/BGC0001003.json
@@ -21,10 +21,12 @@
         {
             "comments": [
                 "Linked new PubChem id for α-lipomycin (pubchem:54723870)",
-                "Update structure (SMILES) for α-lipomycin"
+                "Update structure (SMILES) for α-lipomycin",
+                "Corrected NRP module activity"
             ],
             "contributors": [
-                "5UL74VURKJ25VSPPPO3H2NYB"
+                "5UL74VURKJ25VSPPPO3H2NYB",
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.1"
         }
@@ -183,7 +185,7 @@
                                     "Glutamate"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "1"
                         }

--- a/data/BGC0001006.json
+++ b/data/BGC0001006.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -134,7 +143,7 @@
                     "gene_id": "ABP55493.1",
                     "modules": [
                         {
-                            "active": false,
+                            "active": true,
                             "module_number": "0"
                         }
                     ]

--- a/data/BGC0001007.json
+++ b/data/BGC0001007.json
@@ -17,6 +17,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -105,7 +114,7 @@
                     "gene_id": "ABV99085.1",
                     "modules": [
                         {
-                            "active": false,
+                            "active": true,
                             "module_number": "0"
                         }
                     ]

--- a/data/BGC0001010.json
+++ b/data/BGC0001010.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -162,7 +171,7 @@
                                     "Cysteine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Heterocyclization",
                             "modification_domains": [
                                 "Oxidation"
@@ -184,7 +193,7 @@
                                     "Cysteine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Heterocyclization",
                             "modification_domains": [
                                 "Oxidation"
@@ -206,7 +215,7 @@
                                     "Glycine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "7"
                         }

--- a/data/BGC0001014.json
+++ b/data/BGC0001014.json
@@ -20,7 +20,8 @@
         },
         {
             "comments": [
-                "Linked new NPAtlas id for micacocidin (npatlas:1634)"
+                "Linked new NPAtlas id for micacocidin (npatlas:1634)",
+                "Corrected NRP module activity"
             ],
             "contributors": [
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
@@ -204,7 +205,7 @@
                     "gene_id": "CAD15508.1",
                     "modules": [
                         {
-                            "active": false,
+                            "active": true,
                             "module_number": "0"
                         },
                         {
@@ -217,7 +218,7 @@
                                     "Cysteine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Heterocyclization",
                             "modification_domains": [
                                 "Methylation"
@@ -225,7 +226,7 @@
                             "module_number": "2"
                         },
                         {
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Heterocyclization",
                             "module_number": "3"
                         }
@@ -244,7 +245,7 @@
                                     "Cysteine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Heterocyclization",
                             "modification_domains": [
                                 "Methylation"

--- a/data/BGC0001016.json
+++ b/data/BGC0001016.json
@@ -17,6 +17,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -71,7 +80,7 @@
                                     "Arginine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "11"
                         }
@@ -87,7 +96,7 @@
                                     "Leucine / Arginine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "9"
                         },
@@ -98,7 +107,7 @@
                                     "Aspartate / N-methylaspartate"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "10"
                         }
@@ -114,7 +123,7 @@
                                     "Serine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "modification_domains": [
                                 "Methylation"
                             ],
@@ -127,7 +136,7 @@
                                     "Alanine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "8"
                         }
@@ -143,7 +152,7 @@
                                     "Hydrocinnamate"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "module_number": "0"
                         }
                     ]
@@ -152,7 +161,7 @@
                     "gene_id": "AAO62582.1",
                     "modules": [
                         {
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "modification_domains": [
                                 "Aminotransferase"
@@ -166,7 +175,7 @@
                                     "Glutamine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "6"
                         }

--- a/data/BGC0001017.json
+++ b/data/BGC0001017.json
@@ -20,7 +20,8 @@
         },
         {
             "comments": [
-                "Linked new NPAtlas id for microcystin LR (npatlas:593)"
+                "Linked new NPAtlas id for microcystin LR (npatlas:593)",
+                "Corrected NRP module activity"
             ],
             "contributors": [
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
@@ -234,7 +235,7 @@
                                     "Phenylacetate"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "module_number": "0"
                         }
                     ]
@@ -252,12 +253,12 @@
                                     "Glutamate"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "3"
                         },
                         {
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "4"
                         }
@@ -276,7 +277,7 @@
                                     "Serine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "modification_domains": [
                                 "Methylation"
                             ],
@@ -292,7 +293,7 @@
                                     "Alanine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "7"
                         }
@@ -311,7 +312,7 @@
                                     "Leucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "8"
                         },
@@ -325,7 +326,7 @@
                                     "D-N2-methylasparagine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "9"
                         }
@@ -344,7 +345,7 @@
                                     "Arginine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "10"
                         }

--- a/data/BGC0001019.json
+++ b/data/BGC0001019.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -212,7 +221,7 @@
                                     "Asparagine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "5"
                         }
@@ -231,7 +240,7 @@
                                     "Glycine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "modification_domains": [
                                 "Methylation"
@@ -248,7 +257,7 @@
                                     "Tryptophan"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "8"
                         },
@@ -262,7 +271,7 @@
                                     "Glycine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "9"
                         }
@@ -281,7 +290,7 @@
                                     "Glycine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "10"
                         }

--- a/data/BGC0001023.json
+++ b/data/BGC0001023.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -106,7 +115,7 @@
                                     "Threonine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "modification_domains": [
                                 "Methylation"
@@ -123,7 +132,7 @@
                                     "Leucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "3"
                         }
@@ -142,12 +151,12 @@
                                     "Alanine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "4"
                         },
                         {
-                            "active": true,
+                            "active": false,
                             "c_dom_subtype": "LCL",
                             "module_number": "5",
                             "non_canonical": {
@@ -169,7 +178,7 @@
                                     "Alanine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "6"
                         },
@@ -183,7 +192,7 @@
                                     "Glutamine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "7"
                         }

--- a/data/BGC0001024.json
+++ b/data/BGC0001024.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -161,7 +170,7 @@
                                     "Cysteine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Heterocyclization",
                             "modification_domains": [
                                 "Oxidation"
@@ -180,7 +189,7 @@
                                     "Cysteine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Heterocyclization",
                             "modification_domains": [
                                 "Oxidation"
@@ -202,7 +211,7 @@
                                     "Glycine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "8"
                         }

--- a/data/BGC0001028.json
+++ b/data/BGC0001028.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -162,7 +171,7 @@
                                     "Isoleucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "1"
                         },
@@ -176,7 +185,7 @@
                                     "Serine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "2"
                         },
@@ -190,7 +199,7 @@
                                     "Proline"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "3"
                         },
@@ -204,7 +213,7 @@
                                     "Leucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "4"
                         }
@@ -223,7 +232,7 @@
                                     "Leucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "6"
                         },
@@ -237,7 +246,7 @@
                                     "Glycine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "7"
                         },
@@ -251,7 +260,7 @@
                                     "Asparigine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "8"
                         }
@@ -270,7 +279,7 @@
                                     "Proline"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "10"
                         },
@@ -284,7 +293,7 @@
                                     "Tyrosine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "9"
                         }

--- a/data/BGC0001029.json
+++ b/data/BGC0001029.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -63,7 +72,7 @@
                                     "VGVWVAASGK"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "module_number": "0"
                         }
                     ]
@@ -81,7 +90,7 @@
                                     "DAWLFGLIDK"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "4"
                         },
@@ -95,7 +104,7 @@
                                     "DILALGLIWK"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "5"
                         }
@@ -114,7 +123,7 @@
                                     "DVQFIAHVVK"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "6"
                         },
@@ -128,7 +137,7 @@
                                     "DAWTIAAVCK"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "7"
                         },
@@ -142,7 +151,7 @@
                                     "DAFFLGVTFK"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "8"
                         },
@@ -156,7 +165,7 @@
                                     "DVQFIAHVVK"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "9"
                         }

--- a/data/BGC0001034.json
+++ b/data/BGC0001034.json
@@ -22,10 +22,12 @@
             "comments": [
                 "Update compound structure (SMILES) for pellasoren",
                 "Linked new PubChem id for pellasoren (pubchem:60145150)",
-                "Add new compound: pellasoren B"
+                "Add new compound: pellasoren B",
+                "Corrected NRP module activity"
             ],
             "contributors": [
-                "5UL74VURKJ25VSPPPO3H2NYB"
+                "5UL74VURKJ25VSPPPO3H2NYB",
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.1"
         }
@@ -218,7 +220,7 @@
                                     "Alanine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "2"
                         }

--- a/data/BGC0001035.json
+++ b/data/BGC0001035.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -327,7 +336,7 @@
                     "gene_id": "EPE34341.1",
                     "modules": [
                         {
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Starter",
                             "module_number": "1"
                         },
@@ -341,7 +350,7 @@
                                     "4,5-dihydroxyornithine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "2"
                         },
@@ -355,7 +364,7 @@
                                     "Threonine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "3"
                         },
@@ -369,7 +378,7 @@
                                     "4-Hydroxyproline"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "4"
                         },
@@ -383,7 +392,7 @@
                                     "3,4-hydroxyhomotyrosine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "5"
                         },
@@ -397,7 +406,7 @@
                                     "3-hydroxyglutamine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "6"
                         },
@@ -411,7 +420,7 @@
                                     "3-hydroxy-4-methylproline"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "7"
                         }

--- a/data/BGC0001037.json
+++ b/data/BGC0001037.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -171,7 +180,7 @@
                                     "Phenylalanine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "2"
                         }

--- a/data/BGC0001038.json
+++ b/data/BGC0001038.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -453,7 +462,7 @@
                                     "Proline"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "module_number": "0"
                         }
                     ]

--- a/data/BGC0001048.json
+++ b/data/BGC0001048.json
@@ -20,10 +20,12 @@
         },
         {
             "comments": [
-                "Add new compound: tallysomycin B"
+                "Add new compound: tallysomycin B",
+                "Corrected NRP module activity"
             ],
             "contributors": [
-                "5UL74VURKJ25VSPPPO3H2NYB"
+                "5UL74VURKJ25VSPPPO3H2NYB",
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.1"
         }
@@ -477,7 +479,7 @@
                                     "Asparigine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "4"
                         },
@@ -491,7 +493,7 @@
                                     "Histidine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "5"
                         }
@@ -510,7 +512,7 @@
                                     "Alanine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "6"
                         }
@@ -529,7 +531,7 @@
                                     "Threonine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "8"
                         }
@@ -539,7 +541,7 @@
                     "gene_id": "ABL74940.1",
                     "modules": [
                         {
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Starter",
                             "module_number": "1"
                         },
@@ -553,7 +555,7 @@
                                     "Serine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "2"
                         },
@@ -567,7 +569,7 @@
                                     "Asparigine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "3"
                         }
@@ -577,7 +579,7 @@
                     "gene_id": "ABL74941.1",
                     "modules": [
                         {
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "3"
                         }
@@ -596,7 +598,7 @@
                                     "Cysteine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Heterocyclization",
                             "modification_domains": [
                                 "Unknown"
@@ -604,7 +606,7 @@
                             "module_number": "10"
                         },
                         {
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Heterocyclization",
                             "module_number": "11"
                         },
@@ -618,7 +620,7 @@
                                     "Beta-alanine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "9"
                         }
@@ -628,7 +630,7 @@
                     "gene_id": "ABL74946.1",
                     "modules": [
                         {
-                            "active": false,
+                            "active": true,
                             "modification_domains": [
                                 "Oxidation"
                             ],

--- a/data/BGC0001049.json
+++ b/data/BGC0001049.json
@@ -19,6 +19,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -139,7 +148,7 @@
                                     "Tyrosine"
                                 ]
                             },
-                            "active": true,
+                            "active": false,
                             "c_dom_subtype": "LCL",
                             "module_number": "2"
                         }

--- a/data/BGC0001050.json
+++ b/data/BGC0001050.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -93,7 +102,7 @@
                     "gene_id": "AGC65516.1",
                     "modules": [
                         {
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Starter",
                             "module_number": "1"
                         },
@@ -142,7 +151,7 @@
                             }
                         },
                         {
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "5"
                         }
@@ -161,7 +170,7 @@
                                     "Tyrosine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "modification_domains": [
                                 "Methylation"

--- a/data/BGC0001051.json
+++ b/data/BGC0001051.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -137,7 +146,7 @@
                                     "Cysteine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Heterocyclization",
                             "modification_domains": [
                                 "Oxidation"

--- a/data/BGC0001052.json
+++ b/data/BGC0001052.json
@@ -20,10 +20,12 @@
         },
         {
             "comments": [
-                "Linked new NPAtlas id for tirandamycin (npatlas:17695)"
+                "Linked new NPAtlas id for tirandamycin (npatlas:17695)",
+                "Corrected NRP module activity"
             ],
             "contributors": [
-                "5UL74VURKJ25VSPPPO3H2NYB"
+                "5UL74VURKJ25VSPPPO3H2NYB",
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.1"
         }
@@ -74,7 +76,7 @@
                                     "Glycine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "8"
                         }

--- a/data/BGC0001054.json
+++ b/data/BGC0001054.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -171,12 +180,12 @@
                     "gene_id": "XNC1_1711",
                     "modules": [
                         {
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "3"
                         },
                         {
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "4"
                         }
@@ -186,7 +195,7 @@
                     "gene_id": "XNC1_1701",
                     "modules": [
                         {
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "1"
                         }

--- a/data/BGC0001056.json
+++ b/data/BGC0001056.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -344,7 +353,7 @@
                                     "Aspartate"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "B0"
                         },
@@ -358,7 +367,7 @@
                                     "Histidine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "B1"
                         },
@@ -372,7 +381,7 @@
                                     "Asparagine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "B2"
                         },
@@ -386,7 +395,7 @@
                                     "Asparagine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "B3"
                         }
@@ -405,7 +414,7 @@
                                     "Threonine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "B4"
                         },
@@ -419,7 +428,7 @@
                                     "Valine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "B5"
                         }

--- a/data/BGC0001058.json
+++ b/data/BGC0001058.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -568,7 +577,7 @@
                                     "Asparigine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "4"
                         },
@@ -582,7 +591,7 @@
                                     "Histidine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "5"
                         }
@@ -601,7 +610,7 @@
                                     "Homoserine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "6"
                         }
@@ -611,7 +620,7 @@
                     "gene_id": "ACG60777.1",
                     "modules": [
                         {
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "8"
                         }
@@ -630,7 +639,7 @@
                                     "Serine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "2"
                         },
@@ -644,7 +653,7 @@
                                     "Asparigine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "3"
                         }
@@ -654,7 +663,7 @@
                     "gene_id": "ACG60775.1",
                     "modules": [
                         {
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "3"
                         }
@@ -673,7 +682,7 @@
                                     "Cysteine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "10"
                         },
@@ -687,7 +696,7 @@
                                     "Cysteine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Heterocyclization",
                             "modification_domains": [
                                 "Oxidation"
@@ -704,7 +713,7 @@
                                     "Beta-alanine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "9"
                         }
@@ -714,7 +723,7 @@
                     "gene_id": "ACG60770.1",
                     "modules": [
                         {
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "12"
                         }
@@ -724,7 +733,7 @@
                     "gene_id": "ACG60783.1",
                     "modules": [
                         {
-                            "active": true,
+                            "active": false,
                             "c_dom_subtype": "LCL",
                             "module_number": "13"
                         }
@@ -734,7 +743,7 @@
                     "gene_id": "ACG60752.1",
                     "modules": [
                         {
-                            "active": true,
+                            "active": false,
                             "c_dom_subtype": "LCL",
                             "module_number": "14"
                         }
@@ -753,7 +762,7 @@
                                     "Valine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "module_number": "8"
                         }
                     ]

--- a/data/BGC0001069.json
+++ b/data/BGC0001069.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -165,7 +174,7 @@
                                     "Serine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Heterocyclization",
                             "module_number": "9"
                         }

--- a/data/BGC0001070.json
+++ b/data/BGC0001070.json
@@ -17,6 +17,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -133,7 +142,7 @@
                                     "Glycine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "6"
                         }
@@ -155,7 +164,7 @@
                                     "Beta-alanine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "16"
                         }

--- a/data/BGC0001071.json
+++ b/data/BGC0001071.json
@@ -20,7 +20,8 @@
         },
         {
             "comments": [
-                "Linked new NPAtlas id for nosperin (npatlas:20215)"
+                "Linked new NPAtlas id for nosperin (npatlas:20215)",
+                "Corrected NRP module activity"
             ],
             "contributors": [
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
@@ -76,7 +77,7 @@
                                     "Proline"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "10"
                         },
@@ -90,7 +91,7 @@
                                     "Glycine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "5"
                         }

--- a/data/BGC0001084.json
+++ b/data/BGC0001084.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -72,7 +81,7 @@
                                     "Proline"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "1"
                         },
@@ -86,7 +95,7 @@
                                     "Tryptophan"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "2"
                         }

--- a/data/BGC0001089.json
+++ b/data/BGC0001089.json
@@ -20,10 +20,12 @@
         },
         {
             "comments": [
-                "Linked new PubChem id for bacillaene (pubchem:25144999)"
+                "Linked new PubChem id for bacillaene (pubchem:25144999)",
+                "Corrected NRP module activity"
             ],
             "contributors": [
-                "5UL74VURKJ25VSPPPO3H2NYB"
+                "5UL74VURKJ25VSPPPO3H2NYB",
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.1"
         }
@@ -250,7 +252,7 @@
                     "gene_id": "YP001421292",
                     "modules": [
                         {
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "0"
                         },
@@ -261,7 +263,7 @@
                                     "Glycine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "1"
                         }
@@ -271,7 +273,7 @@
                     "gene_id": "YP001421295",
                     "modules": [
                         {
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "11"
                         }

--- a/data/BGC0001090.json
+++ b/data/BGC0001090.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -115,12 +124,12 @@
                     "gene_id": "ABS74181",
                     "modules": [
                         {
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "1"
                         },
                         {
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "modification_domains": [
                                 "Amination"
@@ -137,12 +146,12 @@
                                     "Asparagine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "4"
                         },
                         {
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "5"
                         }
@@ -161,7 +170,7 @@
                                     "Tyrosine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "module_number": "5"
                         },
                         {
@@ -174,7 +183,7 @@
                                     "Asparagine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "6"
                         },
@@ -188,7 +197,7 @@
                                     "Proline"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "7"
                         },
@@ -202,12 +211,12 @@
                                     "Glutamate"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "8"
                         },
                         {
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "9"
                         }
@@ -226,7 +235,7 @@
                                     "Threonine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "10"
                         },
@@ -240,7 +249,7 @@
                                     "Serine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "module_number": "9"
                         }
                     ]

--- a/data/BGC0001095.json
+++ b/data/BGC0001095.json
@@ -21,10 +21,12 @@
         },
         {
             "comments": [
-                "Linked new NPAtlas id for fengycin (npatlas:20186)"
+                "Linked new NPAtlas id for fengycin (npatlas:20186)",
+                "Corrected NRP module activity"
             ],
             "contributors": [
-                "5UL74VURKJ25VSPPPO3H2NYB"
+                "5UL74VURKJ25VSPPPO3H2NYB",
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.1"
         }
@@ -149,7 +151,7 @@
                                     "Glutamate"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "1"
                         },
@@ -163,7 +165,7 @@
                                     "Ornithine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "2"
                         }
@@ -182,7 +184,7 @@
                                     "Tyrosine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "3"
                         },
@@ -196,7 +198,7 @@
                                     "Threonine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "4"
                         }
@@ -215,7 +217,7 @@
                                     "Glutamate"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "5"
                         },
@@ -229,7 +231,7 @@
                                     "Valine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "6"
                         }
@@ -248,7 +250,7 @@
                                     "Proline"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "7"
                         },
@@ -262,7 +264,7 @@
                                     "Glutamate"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "8"
                         },
@@ -276,7 +278,7 @@
                                     "Tyrosine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "9"
                         }
@@ -295,7 +297,7 @@
                                     "Isoleucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "10"
                         }

--- a/data/BGC0001099.json
+++ b/data/BGC0001099.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -294,7 +303,7 @@
                                     "Glycine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "2"
                         }

--- a/data/BGC0001101.json
+++ b/data/BGC0001101.json
@@ -17,6 +17,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -390,7 +399,7 @@
                                     "D-alanine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "module_number": "0"
                         }
                     ]
@@ -399,7 +408,7 @@
                     "gene_id": "AAN85529.1",
                     "modules": [
                         {
-                            "active": false,
+                            "active": true,
                             "module_number": "0"
                         }
                     ]
@@ -417,7 +426,7 @@
                                     "Cysteine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "modification_domains": [
                                 "Oxidation"

--- a/data/BGC0001102.json
+++ b/data/BGC0001102.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -58,7 +67,7 @@
                     "gene_id": "ABC35922.1",
                     "modules": [
                         {
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "0"
                         }
@@ -68,7 +77,7 @@
                     "gene_id": "ABC35796.1",
                     "modules": [
                         {
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "3"
                         }
@@ -87,7 +96,7 @@
                                     "Proprionate"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "module_number": "3"
                         }
                     ]

--- a/data/BGC0001105.json
+++ b/data/BGC0001105.json
@@ -20,10 +20,12 @@
         },
         {
             "comments": [
-                "Update compound structure (SMILES) for onnamide A"
+                "Update compound structure (SMILES) for onnamide A",
+                "Corrected NRP module activity"
             ],
             "contributors": [
-                "5UL74VURKJ25VSPPPO3H2NYB"
+                "5UL74VURKJ25VSPPPO3H2NYB",
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.1"
         }
@@ -82,7 +84,7 @@
                                     "Glycine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "5"
                         }
@@ -101,7 +103,7 @@
                                     "Arginine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "14"
                         }

--- a/data/BGC0001110.json
+++ b/data/BGC0001110.json
@@ -23,10 +23,12 @@
         {
             "comments": [
                 "Update compound structure (SMILES) for psymberin",
-                "Linked new PubChem id for psymberin (pubchem:11692946)"
+                "Linked new PubChem id for psymberin (pubchem:11692946)",
+                "Corrected NRP module activity"
             ],
             "contributors": [
-                "5UL74VURKJ25VSPPPO3H2NYB"
+                "5UL74VURKJ25VSPPPO3H2NYB",
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.1"
         }
@@ -117,7 +119,7 @@
                                     "Glycine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "4"
                         }

--- a/data/BGC0001111.json
+++ b/data/BGC0001111.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -144,7 +153,7 @@
                                     "Glycine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "modification_domains": [
                                 "Methylation"
@@ -166,7 +175,7 @@
                                     "Serine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Heterocyclization",
                             "modification_domains": [
                                 "Oxidation"

--- a/data/BGC0001112.json
+++ b/data/BGC0001112.json
@@ -17,6 +17,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -79,7 +88,7 @@
                     "gene_id": "rhiA, CAL69888.1",
                     "modules": [
                         {
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "1"
                         }
@@ -98,7 +107,7 @@
                                     "Serine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "modification_domains": [
                                 "Oxidation"
                             ],

--- a/data/BGC0001120.json
+++ b/data/BGC0001120.json
@@ -21,10 +21,12 @@
         },
         {
             "comments": [
-                "Update compound structure (SMILES) for burkholderic acid"
+                "Update compound structure (SMILES) for burkholderic acid",
+                "Corrected NRP module activity"
             ],
             "contributors": [
-                "5UL74VURKJ25VSPPPO3H2NYB"
+                "5UL74VURKJ25VSPPPO3H2NYB",
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.1"
         }
@@ -75,7 +77,7 @@
                     "gene_id": "ABC36203",
                     "modules": [
                         {
-                            "active": false,
+                            "active": true,
                             "module_number": "A1"
                         }
                     ]
@@ -84,7 +86,7 @@
                     "gene_id": "ABC35796",
                     "modules": [
                         {
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "B3"
                         }

--- a/data/BGC0001122.json
+++ b/data/BGC0001122.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -101,7 +110,7 @@
                                     "Leucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "1"
                         }

--- a/data/BGC0001131.json
+++ b/data/BGC0001131.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -66,7 +75,7 @@
                                     "Serine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "module_number": "1"
                         },
                         {
@@ -79,7 +88,7 @@
                                     "Glutamine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "2"
                         },
@@ -93,7 +102,7 @@
                                     "Phenylalanine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "3"
                         },
@@ -107,7 +116,7 @@
                                     "Leucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "4"
                         },
@@ -118,7 +127,7 @@
                                     "Phenylalanine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "5"
                         },
@@ -132,7 +141,7 @@
                                     "Lysine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "6"
                         }

--- a/data/BGC0001132.json
+++ b/data/BGC0001132.json
@@ -17,6 +17,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -61,7 +70,7 @@
                                     "Valine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "1"
                         },
@@ -89,7 +98,7 @@
                                     "Valine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "3"
                         },
@@ -103,7 +112,7 @@
                                     "Valine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "4"
                         }

--- a/data/BGC0001133.json
+++ b/data/BGC0001133.json
@@ -21,10 +21,12 @@
         },
         {
             "comments": [
-                "Refined location to exclude flanking genes"
+                "Refined location to exclude flanking genes",
+                "Corrected NRP module activity"
             ],
             "contributors": [
-                "SJG3CBEHSM6A3I74YXLH6GLA"
+                "SJG3CBEHSM6A3I74YXLH6GLA",
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.1"
         }
@@ -73,7 +75,7 @@
                                     "Threonine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "1"
                         },
@@ -87,7 +89,7 @@
                                     "Serine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "2"
                         },
@@ -102,7 +104,7 @@
                                     "Phenylalanine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "3"
                         },
@@ -116,7 +118,7 @@
                                     "Leucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "4"
                         }
@@ -135,7 +137,7 @@
                                     "Leucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "5"
                         },
@@ -149,7 +151,7 @@
                                     "Leucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "6"
                         },
@@ -163,7 +165,7 @@
                                     "Serine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "7"
                         }

--- a/data/BGC0001135.json
+++ b/data/BGC0001135.json
@@ -17,6 +17,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -68,7 +77,7 @@
                                     "Arginine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "1"
                         },

--- a/data/BGC0001136.json
+++ b/data/BGC0001136.json
@@ -20,10 +20,12 @@
         },
         {
             "comments": [
-                "Linked new PubChem id for desmethylbassianin (pubchem:91820224)"
+                "Linked new PubChem id for desmethylbassianin (pubchem:91820224)",
+                "Corrected NRP module activity"
             ],
             "contributors": [
-                "5UL74VURKJ25VSPPPO3H2NYB"
+                "5UL74VURKJ25VSPPPO3H2NYB",
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.1"
         }
@@ -157,7 +159,7 @@
                                     "Tyrosine"
                                 ]
                             },
-                            "active": true,
+                            "active": false,
                             "c_dom_subtype": "Unknown",
                             "module_number": "2"
                         }

--- a/data/BGC0001149.json
+++ b/data/BGC0001149.json
@@ -21,10 +21,12 @@
         {
             "comments": [
                 "Add new compound structure (SMILES) for brabantamide A",
-                "Linked new PubChem id for brabantamide A (pubchem:129821380)"
+                "Linked new PubChem id for brabantamide A (pubchem:129821380)",
+                "Corrected NRP module activity"
             ],
             "contributors": [
-                "5UL74VURKJ25VSPPPO3H2NYB"
+                "5UL74VURKJ25VSPPPO3H2NYB",
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.1"
         }
@@ -162,7 +164,7 @@
                                     "Serine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Starter",
                             "module_number": "1"
                         },
@@ -176,7 +178,7 @@
                                     "Proline"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "2"
                         }

--- a/data/BGC0001152.json
+++ b/data/BGC0001152.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -190,7 +199,7 @@
                     "gene_id": "ACA34358.1",
                     "modules": [
                         {
-                            "active": false,
+                            "active": true,
                             "module_number": "0"
                         }
                     ]
@@ -208,7 +217,7 @@
                                     "Threonine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Starter",
                             "module_number": "2"
                         },
@@ -222,7 +231,7 @@
                                     "Valine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "3"
                         },
@@ -236,7 +245,7 @@
                                     "Tyrosine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "4"
                         },
@@ -250,7 +259,7 @@
                                     "Allo-threonine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "5"
                         },
@@ -264,7 +273,7 @@
                                     "Asparigine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "6"
                         },
@@ -278,7 +287,7 @@
                                     "D-alanine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "7"
                         }

--- a/data/BGC0001153.json
+++ b/data/BGC0001153.json
@@ -17,6 +17,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -143,7 +152,7 @@
                                     "2,4-Diaminobutyric acid"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Starter",
                             "module_number": "0"
                         },
@@ -157,7 +166,7 @@
                                     "Threonine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "1"
                         },
@@ -171,7 +180,7 @@
                                     "L-2,4-Diaminobutyric acid"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "2"
                         },
@@ -185,7 +194,7 @@
                                     "L-2,4-Diaminobutyric acid"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "3"
                         },
@@ -199,12 +208,12 @@
                                     "L-2,4-Diaminobutyric acid"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "4"
                         },
                         {
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "5"
                         }
@@ -214,7 +223,7 @@
                     "gene_id": "AEZ51516.1",
                     "modules": [
                         {
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "10"
                         },
@@ -228,7 +237,7 @@
                                     "Phenylalanine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "module_number": "6"
                         },
                         {
@@ -241,7 +250,7 @@
                                     "Leucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "7"
                         },
@@ -255,7 +264,7 @@
                                     "L-2,4-Diaminobutyric acid"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "8"
                         },
@@ -269,7 +278,7 @@
                                     "L-2,4-Diaminobutyric acid"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "9"
                         }
@@ -288,7 +297,7 @@
                                     "Threonine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "module_number": "11"
                         }
                     ]

--- a/data/BGC0001166.json
+++ b/data/BGC0001166.json
@@ -17,6 +17,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -85,7 +94,7 @@
                                     "Proline"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "modification_domains": [
                                 "Unknown"
@@ -102,7 +111,7 @@
                                     "Alanine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "2"
                         },
@@ -116,7 +125,7 @@
                                     "D-Alanine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "3"
                         },
@@ -130,7 +139,7 @@
                                     "2-amino-9,10-epoxi-8-oxodecanoic acid"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "4"
                         }

--- a/data/BGC0001168.json
+++ b/data/BGC0001168.json
@@ -17,6 +17,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -112,7 +121,7 @@
                                     "Arginine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "module_number": "1"
                         }
                     ]

--- a/data/BGC0001178.json
+++ b/data/BGC0001178.json
@@ -17,6 +17,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -122,7 +131,7 @@
                                     "4-Hydroxyphenylglycine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "1"
                         },
@@ -136,7 +145,7 @@
                                     "Tyrosine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "2"
                         }
@@ -162,7 +171,7 @@
                                     "3,5-Dihydroxy-phenylglycine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "3"
                         }
@@ -184,7 +193,7 @@
                                     "4-Hydroxyphenylglycine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "5"
                         },
@@ -221,7 +230,7 @@
                                     "Tyrosine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "6"
                         }
@@ -247,7 +256,7 @@
                                     "3,5-Dihydroxy-phenylglycine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "7"
                         }

--- a/data/BGC0001182.json
+++ b/data/BGC0001182.json
@@ -17,6 +17,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -98,7 +107,7 @@
                                     "Tryptophan"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "1"
                         }

--- a/data/BGC0001185.json
+++ b/data/BGC0001185.json
@@ -17,6 +17,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -62,7 +71,7 @@
                                     "dhb"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "module_number": "0"
                         }
                     ]
@@ -80,7 +89,7 @@
                                     "Glycine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Starter",
                             "module_number": "1"
                         },
@@ -94,7 +103,7 @@
                                     "Threonine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "2"
                         }

--- a/data/BGC0001187.json
+++ b/data/BGC0001187.json
@@ -17,6 +17,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -78,7 +87,7 @@
                                     "Glycine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "2"
                         }

--- a/data/BGC0001228.json
+++ b/data/BGC0001228.json
@@ -17,6 +17,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -143,7 +152,7 @@
                                     "Threonine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Starter",
                             "module_number": "1"
                         },
@@ -157,7 +166,7 @@
                                     "Alanine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "2"
                         }
@@ -176,7 +185,7 @@
                                     "Cysteine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "modification_domains": [
                                 "Methylation"
@@ -193,7 +202,7 @@
                                     "Norcoronamic acid"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "modification_domains": [
                                 "Methylation"

--- a/data/BGC0001230.json
+++ b/data/BGC0001230.json
@@ -22,7 +22,8 @@
         {
             "comments": [
                 "Add additional publication",
-                "Removed incorrect polyketide module information"
+                "Removed incorrect polyketide module information",
+                "Corrected NRP module activity"
             ],
             "contributors": [
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
@@ -176,7 +177,7 @@
                                     "Threonine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "2"
                         }
@@ -195,7 +196,7 @@
                                     "Valine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "3"
                         }
@@ -214,7 +215,7 @@
                                     "Hydroxyphenylglycine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "4"
                         },
@@ -228,7 +229,7 @@
                                     "Phenylalanine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "modification_domains": [
                                 "Methylation"
@@ -245,7 +246,7 @@
                                     "Threonine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "6"
                         }
@@ -264,7 +265,7 @@
                                     "Serine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "comments": "cyclizing TE",
                             "module_number": "7"
@@ -284,7 +285,7 @@
                                     "Glycine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "comments": "intermolecular transesterifying TE",
                             "module_number": "8"

--- a/data/BGC0001231.json
+++ b/data/BGC0001231.json
@@ -17,6 +17,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -265,7 +274,7 @@
                                     "Asparagine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "5"
                         }
@@ -284,7 +293,7 @@
                                     "Glycine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "modification_domains": [
                                 "Methylation"
@@ -301,7 +310,7 @@
                                     "Tryptophan"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "8"
                         },
@@ -315,7 +324,7 @@
                                     "Glycine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "9"
                         }
@@ -334,7 +343,7 @@
                                     "Glycine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "10"
                         }

--- a/data/BGC0001327.json
+++ b/data/BGC0001327.json
@@ -19,6 +19,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -190,7 +199,7 @@
                                     "Serine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "2"
                         }
@@ -209,7 +218,7 @@
                                     "Glycine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "modification_domains": [
                                 "Methylation"
@@ -231,12 +240,12 @@
                                     "Beta-hydroxyasparagine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "5"
                         },
                         {
-                            "active": true,
+                            "active": false,
                             "c_dom_subtype": "LCL",
                             "module_number": "6",
                             "non_canonical": {
@@ -254,7 +263,7 @@
                     "gene_id": "WP_030498980.1",
                     "modules": [
                         {
-                            "active": true,
+                            "active": false,
                             "c_dom_subtype": "DCL",
                             "module_number": "7",
                             "non_canonical": {

--- a/data/BGC0001328.json
+++ b/data/BGC0001328.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -297,7 +306,7 @@
                                     "Serine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "3"
                         }
@@ -316,7 +325,7 @@
                                     "Glycine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "5"
                         }
@@ -326,7 +335,7 @@
                     "gene_id": "EWM63006.1",
                     "modules": [
                         {
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "6"
                         }
@@ -345,11 +354,11 @@
                                     "Beta-hydroxyasparagine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "module_number": "6"
                         },
                         {
-                            "active": true,
+                            "active": false,
                             "c_dom_subtype": "LCL",
                             "module_number": "7",
                             "non_canonical": {
@@ -367,7 +376,7 @@
                     "gene_id": "EWM63010.1",
                     "modules": [
                         {
-                            "active": true,
+                            "active": false,
                             "c_dom_subtype": "DCL",
                             "module_number": "8",
                             "non_canonical": {

--- a/data/BGC0001330.json
+++ b/data/BGC0001330.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -176,7 +185,7 @@
                     "gene_id": "WP_047890612.1",
                     "modules": [
                         {
-                            "active": true,
+                            "active": false,
                             "module_number": "0",
                             "non_canonical": {
                                 "evidence": [
@@ -202,7 +211,7 @@
                                     "Glycine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "3"
                         },
@@ -216,7 +225,7 @@
                                     "Serine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "4"
                         }
@@ -235,7 +244,7 @@
                                     "Glycine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "modification_domains": [
                                 "Methylation"
@@ -243,7 +252,7 @@
                             "module_number": "6"
                         },
                         {
-                            "active": true,
+                            "active": false,
                             "c_dom_subtype": "LCL",
                             "module_number": "7",
                             "non_canonical": {

--- a/data/BGC0001331.json
+++ b/data/BGC0001331.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -393,7 +402,7 @@
                                     "Glycine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "3"
                         },
@@ -407,7 +416,7 @@
                                     "Serine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "4"
                         }
@@ -426,7 +435,7 @@
                                     "Glycine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "modification_domains": [
                                 "Methylation"
@@ -434,7 +443,7 @@
                             "module_number": "6"
                         },
                         {
-                            "active": true,
+                            "active": false,
                             "c_dom_subtype": "LCL",
                             "module_number": "7",
                             "non_canonical": {

--- a/data/BGC0001346.json
+++ b/data/BGC0001346.json
@@ -20,10 +20,12 @@
         },
         {
             "comments": [
-                "Add missing citation (issue #6)"
+                "Add missing citation (issue #6)",
+                "Corrected NRP module activity"
             ],
             "contributors": [
-                "3UOU7PODQJXIM6BEPUHHRRA5"
+                "3UOU7PODQJXIM6BEPUHHRRA5",
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.1"
         }
@@ -202,7 +204,7 @@
                                     "Leucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Starter",
                             "module_number": "1"
                         },
@@ -216,7 +218,7 @@
                                     "Aspartate"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "2"
                         }
@@ -235,7 +237,7 @@
                                     "Threonine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "3"
                         },
@@ -249,7 +251,7 @@
                                     "Leucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "4"
                         },
@@ -263,7 +265,7 @@
                                     "Leucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "5"
                         },
@@ -277,7 +279,7 @@
                                     "Glutamine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "6"
                         }
@@ -296,7 +298,7 @@
                                     "Leucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "7"
                         },
@@ -310,7 +312,7 @@
                                     "Isoleucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "8"
                         }

--- a/data/BGC0001417.json
+++ b/data/BGC0001417.json
@@ -17,6 +17,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -198,7 +207,7 @@
                                     "Threonine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "modification_domains": [
                                 "Methylation"
@@ -215,7 +224,7 @@
                                     "Alanine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "3"
                         }
@@ -234,12 +243,12 @@
                                     "Leucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "4"
                         },
                         {
-                            "active": true,
+                            "active": false,
                             "c_dom_subtype": "LCL",
                             "module_number": "5",
                             "non_canonical": {
@@ -261,7 +270,7 @@
                                     "Alanine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "6"
                         },
@@ -275,7 +284,7 @@
                                     "Glutamine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "7"
                         }

--- a/data/BGC0001418.json
+++ b/data/BGC0001418.json
@@ -17,6 +17,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -198,7 +207,7 @@
                                     "Threonine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "modification_domains": [
                                 "Methylation"
@@ -215,7 +224,7 @@
                                     "Alanine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "3"
                         }
@@ -234,12 +243,12 @@
                                     "Leucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "4"
                         },
                         {
-                            "active": true,
+                            "active": false,
                             "c_dom_subtype": "LCL",
                             "module_number": "5",
                             "non_canonical": {
@@ -261,7 +270,7 @@
                                     "Alanine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "6"
                         },
@@ -275,7 +284,7 @@
                                     "Glutamine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "7"
                         }

--- a/data/BGC0001419.json
+++ b/data/BGC0001419.json
@@ -17,6 +17,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -198,7 +207,7 @@
                                     "Threonine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "modification_domains": [
                                 "Methylation"
@@ -215,7 +224,7 @@
                                     "Alanine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "3"
                         }
@@ -234,12 +243,12 @@
                                     "Leucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "4"
                         },
                         {
-                            "active": true,
+                            "active": false,
                             "c_dom_subtype": "LCL",
                             "module_number": "5",
                             "non_canonical": {
@@ -261,7 +270,7 @@
                                     "Alanine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "6"
                         },
@@ -275,7 +284,7 @@
                                     "Glutamine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "7"
                         }

--- a/data/BGC0001420.json
+++ b/data/BGC0001420.json
@@ -17,6 +17,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -217,7 +226,7 @@
                                     "Threonine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "modification_domains": [
                                 "Methylation"
@@ -234,7 +243,7 @@
                                     "Alanine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "3"
                         }
@@ -253,12 +262,12 @@
                                     "Leucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "4"
                         },
                         {
-                            "active": true,
+                            "active": false,
                             "c_dom_subtype": "LCL",
                             "module_number": "5",
                             "non_canonical": {
@@ -280,7 +289,7 @@
                                     "Alanine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "6"
                         },
@@ -294,7 +303,7 @@
                                     "Glutamine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "7"
                         }

--- a/data/BGC0001421.json
+++ b/data/BGC0001421.json
@@ -17,6 +17,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -218,7 +227,7 @@
                                     "Threonine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "modification_domains": [
                                 "Methylation"
@@ -235,7 +244,7 @@
                                     "Alanine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "3"
                         },
@@ -249,7 +258,7 @@
                                     "Leucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "4"
                         },
@@ -263,7 +272,7 @@
                                     "Leucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "5"
                         },
@@ -277,7 +286,7 @@
                                     "Proline"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "6"
                         },
@@ -291,7 +300,7 @@
                                     "Alanine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "7"
                         },
@@ -305,7 +314,7 @@
                                     "Glutamine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "8"
                         }

--- a/data/BGC0001422.json
+++ b/data/BGC0001422.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -235,7 +244,7 @@
                                     "Threonine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "modification_domains": [
                                 "Methylation"
@@ -252,7 +261,7 @@
                                     "Alanine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "3"
                         }
@@ -271,7 +280,7 @@
                                     "Leucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "4"
                         },
@@ -285,7 +294,7 @@
                                     "Proline"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "5"
                         },
@@ -299,7 +308,7 @@
                                     "Alanine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "6"
                         },
@@ -313,7 +322,7 @@
                                     "Glutamine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "7"
                         }

--- a/data/BGC0001423.json
+++ b/data/BGC0001423.json
@@ -17,6 +17,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -213,7 +222,7 @@
                                     "Threonine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "modification_domains": [
                                 "Methylation"
@@ -230,7 +239,7 @@
                                     "Alanine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "3"
                         }
@@ -249,7 +258,7 @@
                                     "Leucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "4"
                         },
@@ -263,7 +272,7 @@
                                     "Proline"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "5"
                         },
@@ -277,7 +286,7 @@
                                     "Glutamine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "6"
                         }

--- a/data/BGC0001424.json
+++ b/data/BGC0001424.json
@@ -20,7 +20,8 @@
         },
         {
             "comments": [
-                "Removed unnecessary external gene annotations"
+                "Removed unnecessary external gene annotations",
+                "Corrected NRP module activity"
             ],
             "contributors": [
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
@@ -121,7 +122,7 @@
                                     "Threonine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "modification_domains": [
                                 "Methylation"
@@ -138,7 +139,7 @@
                                     "Alanine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "3"
                         },
@@ -152,7 +153,7 @@
                                     "Leucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "4"
                         },
@@ -166,7 +167,7 @@
                                     "Proline"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "5"
                         },
@@ -180,7 +181,7 @@
                                     "Glutamine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "6"
                         }

--- a/data/BGC0001425.json
+++ b/data/BGC0001425.json
@@ -17,6 +17,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -219,7 +228,7 @@
                                     "Threonine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "modification_domains": [
                                 "Methylation"
@@ -236,7 +245,7 @@
                                     "Alanine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "3"
                         }
@@ -255,7 +264,7 @@
                                     "Leucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "4"
                         },
@@ -269,7 +278,7 @@
                                     "Proline"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "5"
                         },
@@ -283,7 +292,7 @@
                                     "Alanine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "6"
                         },
@@ -297,7 +306,7 @@
                                     "Glutamine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "7"
                         }

--- a/data/BGC0001426.json
+++ b/data/BGC0001426.json
@@ -17,6 +17,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -216,7 +225,7 @@
                                     "Threonine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "modification_domains": [
                                 "Methylation"
@@ -233,7 +242,7 @@
                                     "Alanine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "3"
                         }
@@ -252,7 +261,7 @@
                                     "Leucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "4"
                         },
@@ -266,7 +275,7 @@
                                     "Proline"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "5"
                         },
@@ -280,7 +289,7 @@
                                     "Alanine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "6"
                         },
@@ -294,7 +303,7 @@
                                     "Glutamine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "7"
                         }

--- a/data/BGC0001427.json
+++ b/data/BGC0001427.json
@@ -17,6 +17,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -217,7 +226,7 @@
                                     "Threonine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "modification_domains": [
                                 "Methylation"
@@ -234,7 +243,7 @@
                                     "Alanine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "3"
                         }
@@ -253,7 +262,7 @@
                                     "Leucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "4"
                         },
@@ -267,7 +276,7 @@
                                     "Proline"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "5"
                         },
@@ -281,7 +290,7 @@
                                     "Alanine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "6"
                         },
@@ -295,7 +304,7 @@
                                     "Glutamine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "7"
                         }

--- a/data/BGC0001428.json
+++ b/data/BGC0001428.json
@@ -17,6 +17,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -234,7 +243,7 @@
                                     "Threonine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "modification_domains": [
                                 "Methylation"
@@ -251,7 +260,7 @@
                                     "Alanine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "3"
                         }
@@ -270,7 +279,7 @@
                                     "Leucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "4"
                         },
@@ -284,7 +293,7 @@
                                     "Proline"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "5"
                         },
@@ -298,7 +307,7 @@
                                     "Alanine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "6"
                         },
@@ -312,7 +321,7 @@
                                     "Glutamine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "7"
                         }

--- a/data/BGC0001429.json
+++ b/data/BGC0001429.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -202,7 +211,7 @@
                                     "Threonine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "modification_domains": [
                                 "Methylation"
@@ -219,7 +228,7 @@
                                     "Leucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "3"
                         }
@@ -238,12 +247,12 @@
                                     "Alanine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "4"
                         },
                         {
-                            "active": true,
+                            "active": false,
                             "c_dom_subtype": "LCL",
                             "module_number": "5",
                             "non_canonical": {
@@ -265,7 +274,7 @@
                                     "Alanine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "6"
                         },
@@ -279,7 +288,7 @@
                                     "Glutamine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "7"
                         }

--- a/data/BGC0001430.json
+++ b/data/BGC0001430.json
@@ -17,6 +17,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -202,7 +211,7 @@
                                     "Threonine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "modification_domains": [
                                 "Methylation"
@@ -219,7 +228,7 @@
                                     "Leucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "3"
                         }
@@ -238,12 +247,12 @@
                                     "Alanine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "4"
                         },
                         {
-                            "active": true,
+                            "active": false,
                             "c_dom_subtype": "LCL",
                             "module_number": "5",
                             "non_canonical": {
@@ -265,7 +274,7 @@
                                     "Alanine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "6"
                         },
@@ -279,7 +288,7 @@
                                     "Glutamine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "7"
                         }

--- a/data/BGC0001431.json
+++ b/data/BGC0001431.json
@@ -17,6 +17,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -199,7 +208,7 @@
                                     "Threonine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "modification_domains": [
                                 "Methylation"
@@ -216,7 +225,7 @@
                                     "Leucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "3"
                         }
@@ -235,12 +244,12 @@
                                     "Alanine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "4"
                         },
                         {
-                            "active": true,
+                            "active": false,
                             "c_dom_subtype": "LCL",
                             "module_number": "5",
                             "non_canonical": {
@@ -262,7 +271,7 @@
                                     "Alanine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "6"
                         },
@@ -276,7 +285,7 @@
                                     "Glutamine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "7"
                         }

--- a/data/BGC0001432.json
+++ b/data/BGC0001432.json
@@ -17,6 +17,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -121,7 +130,7 @@
                                     "Threonine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "modification_domains": [
                                 "Methylation"
@@ -138,7 +147,7 @@
                                     "Alanine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "3"
                         }
@@ -157,12 +166,12 @@
                                     "Leucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "4"
                         },
                         {
-                            "active": true,
+                            "active": false,
                             "c_dom_subtype": "LCL",
                             "module_number": "5",
                             "non_canonical": {
@@ -184,7 +193,7 @@
                                     "Alanine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "6"
                         },
@@ -198,7 +207,7 @@
                                     "Glutamine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "7"
                         }

--- a/data/BGC0001437.json
+++ b/data/BGC0001437.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -86,7 +95,7 @@
                                     "2,3-Dihydroxybenzoic acid"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "module_number": "0"
                         },
                         {
@@ -96,7 +105,7 @@
                                     "(2S,3R)-2-amino-3-hydroxy-4-(4-nitrophenyl)butanoate"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "1"
                         }

--- a/data/BGC0001442.json
+++ b/data/BGC0001442.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -77,7 +86,7 @@
                                     "Threonine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "module_number": "1"
                         }
                     ]
@@ -86,7 +95,7 @@
                     "gene_id": "ATJ34004.1",
                     "modules": [
                         {
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "0"
                         }
@@ -105,7 +114,7 @@
                                     "Proline"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "2"
                         }

--- a/data/BGC0001443.json
+++ b/data/BGC0001443.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -69,7 +78,7 @@
                     "gene_id": "WP_019634556.1",
                     "modules": [
                         {
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "1"
                         }
@@ -79,7 +88,7 @@
                     "gene_id": "WP_026341873.1",
                     "modules": [
                         {
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "2"
                         }
@@ -98,7 +107,7 @@
                                     "Isoleucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "module_number": "2"
                         }
                     ]

--- a/data/BGC0001448.json
+++ b/data/BGC0001448.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -610,7 +619,7 @@
                                     "2,3-Diamino-3-methylpropanoic acid"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "module_number": "2"
                         }
                     ]
@@ -628,12 +637,12 @@
                                     "3-methylaspartic acid"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Starter",
                             "module_number": "1"
                         },
                         {
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "3"
                         },
@@ -647,7 +656,7 @@
                                     "Valine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "4"
                         }
@@ -666,7 +675,7 @@
                                     "Lysine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "module_number": "5"
                         },
@@ -680,7 +689,7 @@
                                     "Hydroxyaspartic acid"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "6"
                         },
@@ -694,7 +703,7 @@
                                     "Aspartate"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "7"
                         },
@@ -708,7 +717,7 @@
                                     "Glycine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "8"
                         },
@@ -722,7 +731,7 @@
                                     "3-methylaspartic acid"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "9"
                         }
@@ -741,7 +750,7 @@
                                     "Valine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "10"
                         },
@@ -755,7 +764,7 @@
                                     "3-Methylproline"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "11"
                         }

--- a/data/BGC0001449.json
+++ b/data/BGC0001449.json
@@ -17,6 +17,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -250,7 +259,7 @@
                                     "3-Methylproline"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Starter",
                             "module_number": "2"
                         }

--- a/data/BGC0001467.json
+++ b/data/BGC0001467.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -100,7 +109,7 @@
                     "gene_id": "WP_026723805.1",
                     "modules": [
                         {
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Starter",
                             "module_number": "0"
                         }
@@ -119,7 +128,7 @@
                                     "2-Hydroxyisovalerate"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "2"
                         }
@@ -138,7 +147,7 @@
                                     "Phenylalanine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "modification_domains": [
                                 "Methylation"

--- a/data/BGC0001469.json
+++ b/data/BGC0001469.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -251,7 +260,7 @@
                                     "Isoleucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "modification_domains": [
                                 "Epimerization"
@@ -273,7 +282,7 @@
                                     "Serine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "modification_domains": [
                                 "Epimerization"
@@ -290,7 +299,7 @@
                                     "Cysteine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Heterocyclization",
                             "modification_domains": [
                                 "Heterocyclization"
@@ -307,7 +316,7 @@
                                     "Cysteine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Heterocyclization",
                             "modification_domains": [
                                 "Heterocyclization"
@@ -324,7 +333,7 @@
                                     "Cysteine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Heterocyclization",
                             "modification_domains": [
                                 "Heterocyclization"
@@ -341,7 +350,7 @@
                                     "Cysteine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Heterocyclization",
                             "modification_domains": [
                                 "Heterocyclization"

--- a/data/BGC0001477.json
+++ b/data/BGC0001477.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -390,7 +399,7 @@
                     "gene_id": "AVV61977.1",
                     "modules": [
                         {
-                            "active": false,
+                            "active": true,
                             "module_number": "0"
                         }
                     ]
@@ -408,7 +417,7 @@
                                     "Glycine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "17"
                         }

--- a/data/BGC0001479.json
+++ b/data/BGC0001479.json
@@ -18,6 +18,15 @@
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -250,7 +259,7 @@
                                     "Phenylalanine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "module_number": "0"
                         },
                         {
@@ -263,7 +272,7 @@
                                     "D-lysine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "1"
                         }
@@ -282,7 +291,7 @@
                                     "Isoleucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "2"
                         }
@@ -301,7 +310,7 @@
                                     "N-methylglycine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "4"
                         },
@@ -315,7 +324,7 @@
                                     "Homophenylalanine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "modification_domains": [
                                 "Methylation"
@@ -332,7 +341,7 @@
                                     "Homotyrosine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "modification_domains": [
                                 "Methylation"
@@ -354,7 +363,7 @@
                                     "Homotyrosine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "5"
                         }

--- a/data/BGC0001833.json
+++ b/data/BGC0001833.json
@@ -8,6 +8,15 @@
                 "J2NUA2GQCUQDOJBDBQUEWJWV"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -68,7 +77,7 @@
                                     "Leucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Starter",
                             "module_number": "1"
                         },
@@ -82,7 +91,7 @@
                                     "Serine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "2"
                         },
@@ -96,7 +105,7 @@
                                     "Serine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Starter",
                             "module_number": "4"
                         },
@@ -110,7 +119,7 @@
                                     "Leucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "5"
                         }

--- a/data/BGC0001842.json
+++ b/data/BGC0001842.json
@@ -8,6 +8,15 @@
                 "KRKW7VUNYGF36O3Z7FAQ6YXG"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -158,7 +167,7 @@
                                     "Leucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Starter",
                             "module_number": "1"
                         },
@@ -172,7 +181,7 @@
                                     "Aspartate"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "2"
                         }
@@ -191,7 +200,7 @@
                                     "Glutamine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "3"
                         },
@@ -205,7 +214,7 @@
                                     "Isoleucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "4"
                         },
@@ -219,7 +228,7 @@
                                     "Leucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "5"
                         },
@@ -233,7 +242,7 @@
                                     "Glutamine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "6"
                         },
@@ -247,7 +256,7 @@
                                     "Serine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "7"
                         }
@@ -266,7 +275,7 @@
                                     "Serine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "10"
                         },
@@ -280,7 +289,7 @@
                                     "Isoleucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "11"
                         },
@@ -294,7 +303,7 @@
                                     "Leucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "8"
                         },
@@ -308,7 +317,7 @@
                                     "Leucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "9"
                         }

--- a/data/BGC0001844.json
+++ b/data/BGC0001844.json
@@ -8,6 +8,15 @@
                 "Z7AIIJAM3U3HR6IYDPQOINM4"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -58,7 +67,7 @@
                                     "Valine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Starter",
                             "module_number": "1"
                         },
@@ -72,7 +81,7 @@
                                     "Phenylalanine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "2"
                         },
@@ -86,7 +95,7 @@
                                     "Glutamate"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "3"
                         },
@@ -100,7 +109,7 @@
                                     "Isoleucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "4"
                         },
@@ -114,7 +123,7 @@
                                     "Alanine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "5"
                         },
@@ -128,7 +137,7 @@
                                     "Isoleucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "6"
                         }

--- a/data/BGC0001873.json
+++ b/data/BGC0001873.json
@@ -8,6 +8,15 @@
                 "EAEHVVGBLF6RHLSTHI74QVQ6"
             ],
             "version": "2.0"
+        },
+        {
+            "comments": [
+                "Corrected NRP module activity"
+            ],
+            "contributors": [
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            "version": "2.1"
         }
     ],
     "cluster": {
@@ -54,7 +63,7 @@
                                     "Serine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Starter",
                             "module_number": "1"
                         },
@@ -68,7 +77,7 @@
                                     "Proline"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "2"
                         }

--- a/data/BGC0001881.json
+++ b/data/BGC0001881.json
@@ -12,7 +12,8 @@
         {
             "comments": [
                 "Fetch compound properties from PubChem",
-                "Add publication"
+                "Add publication",
+                "Corrected NRP module activity"
             ],
             "contributors": [
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
@@ -216,7 +217,7 @@
                                     "O-methyltyrosine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "2"
                         }

--- a/pending/BGC0001853.json
+++ b/pending/BGC0001853.json
@@ -12,7 +12,8 @@
         {
             "comments": [
                 "Fixed NRPS module numbering",
-                "Re-added to MIBiG"
+                "Re-added to MIBiG",
+                "Corrected NRP module activity"
             ],
             "contributors": [
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
@@ -494,7 +495,7 @@
                                     "Threonine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "module_number": "1"
                         }
                     ]
@@ -513,7 +514,7 @@
                                     "Serine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Heterocyclization",
                             "modification_domains": [
                                 "Oxidation"

--- a/pending/BGC0002042.json
+++ b/pending/BGC0002042.json
@@ -2,10 +2,12 @@
     "changelog": [
         {
             "comments": [
-                "Submitted"
+                "Submitted",
+                "Corrected NRP module activity"
             ],
             "contributors": [
-                "P34OM6JOCMMIEQMA65E4OI3N"
+                "P34OM6JOCMMIEQMA65E4OI3N",
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.1"
         }
@@ -456,7 +458,6 @@
                                     "4-acetamidopyrrole-2-carboxylate"
                                 ]
                             },
-                            "active": false,
                             "comments": "not strictly speaking A domain"
                         }
                     ]
@@ -465,7 +466,6 @@
                     "gene_id": "QEG98939.1",
                     "modules": [
                         {
-                            "active": false,
                             "c_dom_subtype": "LCL"
                         }
                     ]
@@ -474,18 +474,12 @@
                     "gene_id": "QEG98951.1",
                     "modules": [
                         {
-                            "active": false,
                             "c_dom_subtype": "LCL"
                         }
                     ]
                 },
                 {
-                    "gene_id": "QEG98953.1",
-                    "modules": [
-                        {
-                            "active": false
-                        }
-                    ]
+                    "gene_id": "QEG98953.1"
                 }
             ]
         },

--- a/pending/BGC0002046.json
+++ b/pending/BGC0002046.json
@@ -2,10 +2,12 @@
     "changelog": [
         {
             "comments": [
-                "Submitted"
+                "Submitted",
+                "Corrected NRP module activity"
             ],
             "contributors": [
-                "6CMFYLN6YIRYRVG5SRRBZ7FY"
+                "6CMFYLN6YIRYRVG5SRRBZ7FY",
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.1"
         }
@@ -63,7 +65,7 @@
                                     "Glycine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "module_number": "0"
                         }
                     ]
@@ -72,7 +74,7 @@
                     "gene_id": "WP_052830344.1",
                     "modules": [
                         {
-                            "active": false,
+                            "active": true,
                             "module_number": "4"
                         },
                         {
@@ -85,7 +87,7 @@
                                     "Glycine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "5"
                         }

--- a/pending/BGC0002048.json
+++ b/pending/BGC0002048.json
@@ -2,10 +2,12 @@
     "changelog": [
         {
             "comments": [
-                "Submitted"
+                "Submitted",
+                "Corrected NRP module activity"
             ],
             "contributors": [
-                "Z7AIIJAM3U3HR6IYDPQOINM4"
+                "Z7AIIJAM3U3HR6IYDPQOINM4",
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.1"
         }
@@ -65,7 +67,7 @@
                                     "Pyrrole carboxylic acid"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "module_number": "0"
                         }
                     ]
@@ -74,7 +76,7 @@
                     "gene_id": "CBW75454.1",
                     "modules": [
                         {
-                            "active": false,
+                            "active": true,
                             "module_number": "1"
                         }
                     ]
@@ -92,7 +94,7 @@
                                     "Valine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Starter",
                             "module_number": "1"
                         },
@@ -106,7 +108,7 @@
                                     "Proline"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "2"
                         },
@@ -120,7 +122,7 @@
                                     "Valine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "3"
                         }
@@ -139,7 +141,7 @@
                                     "Valine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "4"
                         },
@@ -153,7 +155,7 @@
                                     "Threonine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "5"
                         }
@@ -172,7 +174,7 @@
                                     "Serine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "6"
                         },
@@ -186,7 +188,7 @@
                                     "Tyrosine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "7"
                         },
@@ -200,7 +202,7 @@
                                     "Tyrosine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "8"
                         }

--- a/pending/BGC0002050.json
+++ b/pending/BGC0002050.json
@@ -2,10 +2,12 @@
     "changelog": [
         {
             "comments": [
-                "Submitted"
+                "Submitted",
+                "Corrected NRP module activity"
             ],
             "contributors": [
-                "Z7AIIJAM3U3HR6IYDPQOINM4"
+                "Z7AIIJAM3U3HR6IYDPQOINM4",
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.1"
         }
@@ -216,7 +218,7 @@
                                     "Glycine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "6"
                         }
@@ -235,7 +237,7 @@
                                     "Glycine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "module_number": "2"
                         }
                     ]
@@ -253,7 +255,7 @@
                                     "Lysine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Starter",
                             "module_number": "1"
                         }

--- a/pending/BGC0002058.json
+++ b/pending/BGC0002058.json
@@ -2,10 +2,12 @@
     "changelog": [
         {
             "comments": [
-                "Submitted"
+                "Submitted",
+                "Corrected NRP module activity"
             ],
             "contributors": [
-                "BBFIVXCXOEHHFWOS2XMPTW4C"
+                "BBFIVXCXOEHHFWOS2XMPTW4C",
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.1"
         }
@@ -209,7 +211,7 @@
                     "gene_id": "no_accession",
                     "modules": [
                         {
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "1"
                         }

--- a/pending/BGC0002059.json
+++ b/pending/BGC0002059.json
@@ -2,10 +2,12 @@
     "changelog": [
         {
             "comments": [
-                "Submitted"
+                "Submitted",
+                "Corrected NRP module activity"
             ],
             "contributors": [
-                "RLTUJMQB5UUY7AZHW5PDUHV4"
+                "RLTUJMQB5UUY7AZHW5PDUHV4",
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.1"
         }
@@ -60,7 +62,7 @@
                     "gene_id": "sxcD",
                     "modules": [
                         {
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "comments": "catalyzes condensation of amino acid and polyketide",
                             "module_number": "4"
@@ -80,7 +82,7 @@
                                     "Threonine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Unknown",
                             "comments": "catalyzes condensation of amino acid and polyketide",
                             "module_number": "4"

--- a/pending/BGC0002061.json
+++ b/pending/BGC0002061.json
@@ -2,10 +2,12 @@
     "changelog": [
         {
             "comments": [
-                "Submitted"
+                "Submitted",
+                "Corrected NRP module activity"
             ],
             "contributors": [
-                "KTTDKEJDYAQ7MKSNPMBDOYYX"
+                "KTTDKEJDYAQ7MKSNPMBDOYYX",
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.1"
         }
@@ -166,7 +168,7 @@
                                     "Isoleucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "1"
                         },
@@ -180,7 +182,7 @@
                                     "Serine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "2"
                         },
@@ -194,7 +196,7 @@
                                     "4-Methylproline"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "3"
                         },
@@ -208,7 +210,7 @@
                                     "Leucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "4"
                         }
@@ -227,7 +229,7 @@
                                     "Leucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "6"
                         },
@@ -241,7 +243,7 @@
                                     "Glycine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "7"
                         },
@@ -255,7 +257,7 @@
                                     "Asparigine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "DCL",
                             "module_number": "8"
                         }
@@ -274,7 +276,7 @@
                                     "Tyrosine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "10"
                         },
@@ -288,7 +290,7 @@
                                     "Proline"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "9"
                         }

--- a/pending/BGC0002066.json
+++ b/pending/BGC0002066.json
@@ -2,10 +2,12 @@
     "changelog": [
         {
             "comments": [
-                "Submitted"
+                "Submitted",
+                "Corrected NRP module activity"
             ],
             "contributors": [
-                "PAM2M7KUAUIJ3CVOXWVXWGKQ"
+                "PAM2M7KUAUIJ3CVOXWVXWGKQ",
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.1"
         }
@@ -192,7 +194,7 @@
                                     "Tyrosine"
                                 ]
                             },
-                            "active": true,
+                            "active": false,
                             "c_dom_subtype": "LCL",
                             "module_number": "2"
                         }

--- a/pending/BGC0002067.json
+++ b/pending/BGC0002067.json
@@ -2,10 +2,12 @@
     "changelog": [
         {
             "comments": [
-                "Submitted"
+                "Submitted",
+                "Corrected NRP module activity"
             ],
             "contributors": [
-                "PAM2M7KUAUIJ3CVOXWVXWGKQ"
+                "PAM2M7KUAUIJ3CVOXWVXWGKQ",
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.1"
         }
@@ -203,7 +205,7 @@
                                     "Tyrosine"
                                 ]
                             },
-                            "active": true,
+                            "active": false,
                             "c_dom_subtype": "LCL",
                             "module_number": "2"
                         }

--- a/pending/BGC0002071.json
+++ b/pending/BGC0002071.json
@@ -2,10 +2,12 @@
     "changelog": [
         {
             "comments": [
-                "Submitted"
+                "Submitted",
+                "Corrected NRP module activity"
             ],
             "contributors": [
-                "O3ZSI4V6BQREG2DOQHOQ27FT"
+                "O3ZSI4V6BQREG2DOQHOQ27FT",
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.1"
         }
@@ -52,7 +54,7 @@
                                     "Leucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Starter",
                             "module_number": "1"
                         },
@@ -63,7 +65,7 @@
                                     "Leucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "2"
                         },
@@ -74,7 +76,7 @@
                                     "Glutamine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "3"
                         }
@@ -90,7 +92,7 @@
                                     "Leucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "4"
                         },
@@ -101,7 +103,7 @@
                                     "Serine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "5"
                         },
@@ -112,7 +114,7 @@
                                     "Valine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "6"
                         },
@@ -123,7 +125,7 @@
                                     "Leucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "7"
                         },
@@ -134,7 +136,7 @@
                                     "Leucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "8"
                         }

--- a/pending/BGC0002075.json
+++ b/pending/BGC0002075.json
@@ -2,10 +2,12 @@
     "changelog": [
         {
             "comments": [
-                "Submitted"
+                "Submitted",
+                "Corrected NRP module activity"
             ],
             "contributors": [
-                "6CADHILFODRMCII55WHSHZ6V"
+                "6CADHILFODRMCII55WHSHZ6V",
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.1"
         }
@@ -147,7 +149,7 @@
                                     "L-Proline, L-Pipecolic Acid, 3-hydroxyproline, 3-oxoproline"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Starter",
                             "comments": "A feeding study proved A domain specificity",
                             "module_number": "1"

--- a/pending/BGC0002092.json
+++ b/pending/BGC0002092.json
@@ -2,10 +2,12 @@
     "changelog": [
         {
             "comments": [
-                "Submitted"
+                "Submitted",
+                "Corrected NRP module activity"
             ],
             "contributors": [
-                "7JBBERLOMRODNNGUFOT34CPQ"
+                "7JBBERLOMRODNNGUFOT34CPQ",
+                "AAAAAAAAAAAAAAAAAAAAAAAA"
             ],
             "version": "2.1"
         }
@@ -116,7 +118,7 @@
                                     "Leucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Starter",
                             "module_number": "1"
                         },
@@ -130,7 +132,7 @@
                                     "aspartic acid, glutamic acid"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "2"
                         }
@@ -149,7 +151,7 @@
                                     "Threonine, Serine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "3"
                         },
@@ -163,7 +165,7 @@
                                     "Leucine, Valine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "4"
                         },
@@ -177,7 +179,7 @@
                                     "Leucine, Valine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "5"
                         },
@@ -191,7 +193,7 @@
                                     "Serine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "6"
                         }
@@ -210,7 +212,7 @@
                                     "Leucine, Isoleucine, Valine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "10"
                         },
@@ -224,7 +226,7 @@
                                     "Aspartic acid, Glutamic acid, Glutamic acid methyl ester"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "11"
                         },
@@ -238,7 +240,7 @@
                                     "Leucine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "7"
                         },
@@ -252,7 +254,7 @@
                                     "Glutamine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "LCL",
                             "module_number": "8"
                         },
@@ -266,7 +268,7 @@
                                     "Leucine, Valine, aminobutyric acid"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "c_dom_subtype": "Dual",
                             "module_number": "9"
                         }

--- a/scripts/add_changelog.py
+++ b/scripts/add_changelog.py
@@ -38,14 +38,23 @@ def add_changelog(record: Dict[str, Any], release: str, comments: List[str], con
     if not contributors:
         contributors = ["AAAAAAAAAAAAAAAAAAAAAAAA"]
 
-    new_entry = {
-        "comments": comments,
-        "contributors": contributors,
-        "version": release,
-    }
+    previous = record["changelog"][-1]
 
-    record["changelog"].append(new_entry)
+    if previous["version"] != release:
+        new_entry = {
+            "comments": comments,
+            "contributors": contributors,
+            "version": release,
+        }
+        record["changelog"].append(new_entry)
+        return
 
+    for comment in comments:
+        if comment not in previous["comments"]:
+            previous["comments"].append(comment)
+    for contributor in contributors:
+        if contributor not in previous["contributors"]:
+            previous["contributors"].append(contributor)
 
 def amend_changelog(record: Dict[str, Any], release: str, comments: List[str], contributors: List[str]) -> None:
     entry = record["changelog"][-1]


### PR DESCRIPTION
Handles some of #138's reported issues with NRPS module activity being incorrect.

The 1.4 -> 2.0 conversion had an incorrect activity for any NRPS module that wasn't marked in 1.4 as "Iterated". Using the available 1.4 release JSONs, the entries up to, and including, BGC0001830 have been corrected.

**Edit:** This paragraph is no longer relevant, see 9b90f52:
Any entry after BGC0001830 will still have the incorrect activity, but without the 1.4 equivalent data, I can't fix those (although I expect that in almost all cases they'll be the opposite of what the entries currently say).