### PR TITLE
PKS module merges and corrections

### DIFF
--- a/data/BGC0000083.json
+++ b/data/BGC0000083.json
@@ -22,7 +22,8 @@
         {
             "comments": [
                 "Fixed inconsistent gene labelling",
-                "Removed ketoreductase stereochemistry annotation from modules without ketoreductases"
+                "Removed ketoreductase stereochemistry annotation from modules without ketoreductases",
+                "Merged cross-CDS PKS modules"
             ],
             "contributors": [
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
@@ -243,22 +244,12 @@
                                 "Unknown"
                             ],
                             "domains": [
-                                "Ketosynthase"
-                            ],
-                            "genes": [
-                                "ACY01400.1"
-                            ],
-                            "module_number": "3"
-                        },
-                        {
-                            "at_specificities": [
-                                "Unknown"
-                            ],
-                            "domains": [
+                                "Ketosynthase",
                                 "Ketoreductase",
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
+                                "ACY01400.1",
                                 "ACY01401.1"
                             ],
                             "kr_stereochem": "L-OH",
@@ -349,10 +340,12 @@
                             ],
                             "domains": [
                                 "Ketosynthase",
-                                "Dehydratase"
+                                "Dehydratase",
+                                "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
-                                "ACY01401.1"
+                                "ACY01401.1",
+                                "ACY01402.1"
                             ],
                             "module_number": "9"
                         },
@@ -371,18 +364,6 @@
                             ],
                             "kr_stereochem": "Unknown",
                             "module_number": "10"
-                        },
-                        {
-                            "at_specificities": [
-                                "Unknown"
-                            ],
-                            "domains": [
-                                "Thiolation (ACP/PCP)"
-                            ],
-                            "genes": [
-                                "ACY01402.1"
-                            ],
-                            "module_number": "9"
                         }
                     ],
                     "subclass": [

--- a/data/BGC0000097.json
+++ b/data/BGC0000097.json
@@ -24,7 +24,9 @@
             "comments": [
                 "Removed gene names of 'No gene ID'",
                 "Removed duplicate gene name",
-                "Removed ketoreductase stereochemistry annotation from modules without ketoreductases"
+                "Removed ketoreductase stereochemistry annotation from modules without ketoreductases",
+                "Sorted modules by module number",
+                "Corrected module numbering"
             ],
             "contributors": [
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
@@ -402,179 +404,6 @@
                     "modules": [
                         {
                             "at_specificities": [
-                                "Malonyl-CoA"
-                            ],
-                            "domains": [
-                                "Ketosynthase",
-                                "Acyltransferase",
-                                "Ketoreductase",
-                                "Thiolation (ACP/PCP)"
-                            ],
-                            "evidence": "Structure-based inference",
-                            "genes": [
-                                "ACO94500.1"
-                            ],
-                            "kr_stereochem": "Unknown",
-                            "module_number": "11"
-                        },
-                        {
-                            "at_specificities": [
-                                "Methylmalonyl-CoA"
-                            ],
-                            "domains": [
-                                "Ketosynthase",
-                                "Acyltransferase",
-                                "Dehydratase",
-                                "Ketoreductase",
-                                "Thiolation (ACP/PCP)"
-                            ],
-                            "evidence": "Structure-based inference",
-                            "genes": [
-                                "ACO94499.1"
-                            ],
-                            "kr_stereochem": "Unknown",
-                            "module_number": "2"
-                        },
-                        {
-                            "at_specificities": [
-                                "Malonyl-CoA"
-                            ],
-                            "domains": [
-                                "Ketosynthase",
-                                "Acyltransferase",
-                                "Dehydratase",
-                                "Ketoreductase",
-                                "Thiolation (ACP/PCP)"
-                            ],
-                            "evidence": "Structure-based inference",
-                            "genes": [
-                                "ACO94499.1"
-                            ],
-                            "kr_stereochem": "Unknown",
-                            "module_number": "3"
-                        },
-                        {
-                            "at_specificities": [
-                                "Malonyl-CoA"
-                            ],
-                            "domains": [
-                                "Ketosynthase",
-                                "Acyltransferase",
-                                "Dehydratase",
-                                "Ketoreductase",
-                                "Thiolation (ACP/PCP)",
-                                "Thioesterase"
-                            ],
-                            "evidence": "Structure-based inference",
-                            "genes": [
-                                "ACO94498.1"
-                            ],
-                            "kr_stereochem": "Unknown",
-                            "module_number": "4"
-                        },
-                        {
-                            "at_specificities": [
-                                "Malonyl-CoA"
-                            ],
-                            "domains": [
-                                "Ketosynthase",
-                                "Acyltransferase",
-                                "Dehydratase",
-                                "Ketoreductase",
-                                "Thiolation (ACP/PCP)"
-                            ],
-                            "evidence": "Structure-based inference",
-                            "genes": [
-                                "ACO94496.1"
-                            ],
-                            "kr_stereochem": "Unknown",
-                            "module_number": "10"
-                        },
-                        {
-                            "at_specificities": [
-                                "Malonyl-CoA"
-                            ],
-                            "domains": [
-                                "Ketosynthase",
-                                "Acyltransferase",
-                                "Dehydratase",
-                                "Ketoreductase",
-                                "Thiolation (ACP/PCP)"
-                            ],
-                            "evidence": "Structure-based inference",
-                            "genes": [
-                                "ACO94496.1"
-                            ],
-                            "kr_stereochem": "Unknown",
-                            "module_number": "9"
-                        },
-                        {
-                            "at_specificities": [
-                                "Malonyl-CoA"
-                            ],
-                            "domains": [
-                                "Thiolation (ACP/PCP)",
-                                "Ketosynthase",
-                                "Acyltransferase",
-                                "Dehydratase",
-                                "Ketoreductase",
-                                "Thiolation (ACP/PCP)"
-                            ],
-                            "evidence": "Structure-based inference",
-                            "genes": [
-                                "ACO94488.1"
-                            ],
-                            "kr_stereochem": "Unknown",
-                            "module_number": "7"
-                        },
-                        {
-                            "at_specificities": [
-                                "Methylmalonyl-CoA"
-                            ],
-                            "domains": [
-                                "Ketosynthase",
-                                "Acyltransferase",
-                                "Dehydratase",
-                                "Ketoreductase",
-                                "Thiolation (ACP/PCP)"
-                            ],
-                            "evidence": "Structure-based inference",
-                            "genes": [
-                                "ACO94488.1"
-                            ],
-                            "kr_stereochem": "Unknown",
-                            "module_number": "8"
-                        },
-                        {
-                            "at_specificities": [
-                                "Unknown"
-                            ],
-                            "domains": [
-                                "Ketoreductase",
-                                "Thiolation (ACP/PCP)"
-                            ],
-                            "genes": [
-                                "ACO94486.1"
-                            ],
-                            "kr_stereochem": "Unknown",
-                            "module_number": "6"
-                        },
-                        {
-                            "at_specificities": [
-                                "Malonyl-CoA"
-                            ],
-                            "domains": [
-                                "Ketosynthase",
-                                "Acyltransferase"
-                            ],
-                            "evidence": "Structure-based inference",
-                            "genes": [
-                                "ACO94484.1"
-                            ],
-                            "module_number": "5"
-                        },
-                        {
-                            "at_specificities": [
                                 "Methylmalonyl-CoA"
                             ],
                             "domains": [
@@ -641,6 +470,168 @@
                             ],
                             "kr_stereochem": "Unknown",
                             "module_number": "4"
+                        },
+                        {
+                            "at_specificities": [
+                                "Malonyl-CoA"
+                            ],
+                            "domains": [
+                                "Ketosynthase",
+                                "Acyltransferase",
+                                "Ketoreductase",
+                                "Thiolation (ACP/PCP)"
+                            ],
+                            "evidence": "Structure-based inference",
+                            "genes": [
+                                "ACO94484.1",
+                                "ACO94486.1"
+                            ],
+                            "kr_stereochem": "Unknown",
+                            "module_number": "5"
+                        },
+                        {
+                            "at_specificities": [
+                                "Malonyl-CoA"
+                            ],
+                            "domains": [
+                                "Ketosynthase",
+                                "Acyltransferase",
+                                "Dehydratase",
+                                "Ketoreductase",
+                                "Thiolation (ACP/PCP)"
+                            ],
+                            "evidence": "Structure-based inference",
+                            "genes": [
+                                "ACO94488.1"
+                            ],
+                            "kr_stereochem": "Unknown",
+                            "module_number": "6"
+                        },
+                        {
+                            "at_specificities": [
+                                "Methylmalonyl-CoA"
+                            ],
+                            "domains": [
+                                "Ketosynthase",
+                                "Acyltransferase",
+                                "Dehydratase",
+                                "Ketoreductase",
+                                "Thiolation (ACP/PCP)"
+                            ],
+                            "evidence": "Structure-based inference",
+                            "genes": [
+                                "ACO94488.1"
+                            ],
+                            "kr_stereochem": "Unknown",
+                            "module_number": "7"
+                        },
+                        {
+                            "at_specificities": [
+                                "Malonyl-CoA"
+                            ],
+                            "domains": [
+                                "Ketosynthase",
+                                "Acyltransferase",
+                                "Dehydratase",
+                                "Ketoreductase",
+                                "Thiolation (ACP/PCP)"
+                            ],
+                            "evidence": "Structure-based inference",
+                            "genes": [
+                                "ACO94496.1"
+                            ],
+                            "kr_stereochem": "Unknown",
+                            "module_number": "8"
+                        },
+                        {
+                            "at_specificities": [
+                                "Malonyl-CoA"
+                            ],
+                            "domains": [
+                                "Ketosynthase",
+                                "Acyltransferase",
+                                "Dehydratase",
+                                "Ketoreductase",
+                                "Thiolation (ACP/PCP)"
+                            ],
+                            "evidence": "Structure-based inference",
+                            "genes": [
+                                "ACO94496.1"
+                            ],
+                            "kr_stereochem": "Unknown",
+                            "module_number": "9"
+                        },
+                        {
+                            "at_specificities": [
+                                "Malonyl-CoA"
+                            ],
+                            "domains": [
+                                "Ketosynthase",
+                                "Acyltransferase",
+                                "Ketoreductase",
+                                "Thiolation (ACP/PCP)"
+                            ],
+                            "evidence": "Structure-based inference",
+                            "genes": [
+                                "ACO94500.1"
+                            ],
+                            "kr_stereochem": "Unknown",
+                            "module_number": "10"
+                        },
+                        {
+                            "at_specificities": [
+                                "Methylmalonyl-CoA"
+                            ],
+                            "domains": [
+                                "Ketosynthase",
+                                "Acyltransferase",
+                                "Dehydratase",
+                                "Ketoreductase",
+                                "Thiolation (ACP/PCP)"
+                            ],
+                            "evidence": "Structure-based inference",
+                            "genes": [
+                                "ACO94499.1"
+                            ],
+                            "kr_stereochem": "Unknown",
+                            "module_number": "11"
+                        },
+                        {
+                            "at_specificities": [
+                                "Malonyl-CoA"
+                            ],
+                            "domains": [
+                                "Ketosynthase",
+                                "Acyltransferase",
+                                "Dehydratase",
+                                "Ketoreductase",
+                                "Thiolation (ACP/PCP)"
+                            ],
+                            "evidence": "Structure-based inference",
+                            "genes": [
+                                "ACO94499.1"
+                            ],
+                            "kr_stereochem": "Unknown",
+                            "module_number": "12"
+                        },
+                        {
+                            "at_specificities": [
+                                "Malonyl-CoA"
+                            ],
+                            "domains": [
+                                "Ketosynthase",
+                                "Acyltransferase",
+                                "Dehydratase",
+                                "Ketoreductase",
+                                "Thiolation (ACP/PCP)",
+                                "Thioesterase"
+                            ],
+                            "evidence": "Structure-based inference",
+                            "genes": [
+                                "ACO94498.1"
+                            ],
+                            "kr_stereochem": "Unknown",
+                            "module_number": "13"
                         }
                     ],
                     "subclass": [

--- a/data/BGC0000173.json
+++ b/data/BGC0000173.json
@@ -21,7 +21,8 @@
         },
         {
             "comments": [
-                "Removed ketoreductase stereochemistry annotation from modules without ketoreductases"
+                "Removed ketoreductase stereochemistry annotation from modules without ketoreductases",
+                "Merged cross-CDS PKS modules"
             ],
             "contributors": [
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
@@ -216,10 +217,13 @@
                                 "Unknown"
                             ],
                             "domains": [
-                                "Ketosynthase"
+                                "Ketosynthase",
+                                "Dehydratase",
+                                "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
-                                "AFN27480.1"
+                                "AFN27480.1",
+                                "AFN27481.1"
                             ],
                             "module_number": "6",
                             "non_canonical": {
@@ -230,19 +234,6 @@
                                 "non_elongating": false,
                                 "skipped": true
                             }
-                        },
-                        {
-                            "at_specificities": [
-                                "Unknown"
-                            ],
-                            "domains": [
-                                "Dehydratase",
-                                "Thiolation (ACP/PCP)"
-                            ],
-                            "genes": [
-                                "AFN27481.1"
-                            ],
-                            "module_number": "6"
                         },
                         {
                             "at_specificities": [
@@ -267,24 +258,14 @@
                             "domains": [
                                 "Ketosynthase",
                                 "Ketoreductase",
-                                "Dehydratase"
-                            ],
-                            "genes": [
-                                "AFN27481.1"
-                            ],
-                            "kr_stereochem": "L-OH",
-                            "module_number": "8"
-                        },
-                        {
-                            "at_specificities": [
-                                "Unknown"
-                            ],
-                            "domains": [
+                                "Dehydratase",
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
+                                "AFN27481.1",
                                 "AFN27482.1"
                             ],
+                            "kr_stereochem": "L-OH",
                             "module_number": "8"
                         },
                         {
@@ -294,27 +275,14 @@
                             "domains": [
                                 "Ketosynthase",
                                 "Ketoreductase",
-                                "Dehydratase"
-                            ],
-                            "genes": [
-                                "AFN27482.1"
-                            ],
-                            "kr_stereochem": "L-OH",
-                            "module_number": "9",
-                            "pks_mod_doms": [
-                                "Methylation"
-                            ]
-                        },
-                        {
-                            "at_specificities": [
-                                "Unknown"
-                            ],
-                            "domains": [
+                                "Dehydratase",
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
+                                "AFN27482.1",
                                 "AFN27483.1"
                             ],
+                            "kr_stereochem": "L-OH",
                             "module_number": "9",
                             "pks_mod_doms": [
                                 "Methylation"

--- a/data/BGC0000176.json
+++ b/data/BGC0000176.json
@@ -22,10 +22,12 @@
         {
             "comments": [
                 "Removed invalid NRP information",
-                "Removed ketoreductase stereochemistry annotation from modules without ketoreductases"
+                "Removed ketoreductase stereochemistry annotation from modules without ketoreductases",
+                "Reworked PKS modules to match reference paper"
             ],
             "contributors": [
-                "AAAAAAAAAAAAAAAAAAAAAAAA"
+                "AAAAAAAAAAAAAAAAAAAAAAAA",
+                "77MNCE2XEGC43DNOUCFLS2KM"
             ],
             "version": "2.1"
         }
@@ -61,37 +63,16 @@
             "synthases": [
                 {
                     "genes": [
-                        "dfnD",
-                        "dfnI",
-                        "dfnF",
-                        "dfnE",
-                        "dfnA",
-                        "dfnJ",
-                        "dfnG",
-                        "dfnH"
+                        "difA",
+                        "difF",
+                        "difG",
+                        "difH",
+                        "difI",
+                        "difJ",
+                        "difK",
+                        "difL"
                     ],
                     "modules": [
-                        {
-                            "at_specificities": [
-                                "Malonyl-CoA"
-                            ],
-                            "domains": [
-                                "Acyltransferase"
-                            ],
-                            "evidence": "Sequence-based prediction",
-                            "genes": [
-                                "dfnA"
-                            ],
-                            "module_number": "0",
-                            "non_canonical": {
-                                "evidence": [
-                                    "Sequence-based prediction"
-                                ],
-                                "iterated": true,
-                                "non_elongating": false,
-                                "skipped": false
-                            }
-                        },
                         {
                             "at_specificities": [
                                 "Unknown"
@@ -103,7 +84,7 @@
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
-                                "dfnD"
+                                "difF"
                             ],
                             "kr_stereochem": "Unknown",
                             "module_number": "1",
@@ -118,11 +99,10 @@
                             "domains": [
                                 "Ketosynthase",
                                 "Dehydratase",
-                                "Ketoreductase",
-                                "Thiolation (ACP/PCP)"
+                                "Ketoreductase"
                             ],
                             "genes": [
-                                "dfnD"
+                                "difF"
                             ],
                             "kr_stereochem": "Unknown",
                             "module_number": "2"
@@ -132,23 +112,12 @@
                                 "Unknown"
                             ],
                             "domains": [
-                                "Ketosynthase"
-                            ],
-                            "genes": [
-                                "dfnD"
-                            ],
-                            "module_number": "3"
-                        },
-                        {
-                            "at_specificities": [
-                                "Unknown"
-                            ],
-                            "domains": [
-                                "Dehydratase",
+                                "Ketosynthase",
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
-                                "dfnE"
+                                "difF",
+                                "difG"
                             ],
                             "module_number": "3"
                         },
@@ -162,7 +131,7 @@
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
-                                "dfnE"
+                                "difG"
                             ],
                             "kr_stereochem": "Unknown",
                             "module_number": "4"
@@ -172,31 +141,13 @@
                                 "Unknown"
                             ],
                             "domains": [
-                                "Ketosynthase"
-                            ],
-                            "genes": [
-                                "dfnE"
-                            ],
-                            "module_number": "5",
-                            "non_canonical": {
-                                "evidence": [
-                                    "Structure-based inference"
-                                ],
-                                "iterated": false,
-                                "non_elongating": false,
-                                "skipped": true
-                            }
-                        },
-                        {
-                            "at_specificities": [
-                                "Unknown"
-                            ],
-                            "domains": [
+                                "Ketosynthase",
                                 "Dehydratase",
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
-                                "dfnF"
+                                "difG",
+                                "difH"
                             ],
                             "module_number": "5",
                             "non_canonical": {
@@ -215,38 +166,12 @@
                             "domains": [
                                 "Ketosynthase",
                                 "Dehydratase",
-                                "Ketoreductase"
-                            ],
-                            "genes": [
-                                "dfnF"
-                            ],
-                            "kr_stereochem": "Unknown",
-                            "module_number": "6"
-                        },
-                        {
-                            "at_specificities": [
-                                "Unknown"
-                            ],
-                            "domains": [
-                                "Ketosynthase"
-                            ],
-                            "genes": [
-                                "dfnG"
-                            ],
-                            "module_number": "10"
-                        },
-                        {
-                            "at_specificities": [
-                                "Unknown"
-                            ],
-                            "domains": [
-                                "Ketosynthase",
                                 "Ketoreductase",
-                                "Thiolation (ACP/PCP)",
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
-                                "dfnG"
+                                "difH",
+                                "difI"
                             ],
                             "kr_stereochem": "Unknown",
                             "module_number": "6",
@@ -264,7 +189,7 @@
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
-                                "dfnG"
+                                "difI"
                             ],
                             "kr_stereochem": "Unknown",
                             "module_number": "7"
@@ -280,7 +205,7 @@
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
-                                "dfnG"
+                                "difI"
                             ],
                             "kr_stereochem": "Unknown",
                             "module_number": "8"
@@ -295,7 +220,7 @@
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
-                                "dfnG"
+                                "difI"
                             ],
                             "kr_stereochem": "Unknown",
                             "module_number": "9"
@@ -305,14 +230,14 @@
                                 "Unknown"
                             ],
                             "domains": [
+                                "Ketosynthase",
                                 "Dehydratase",
-                                "Ketoreductase",
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
-                                "dfnH"
+                                "difI",
+                                "difJ"
                             ],
-                            "kr_stereochem": "Unknown",
                             "module_number": "10"
                         },
                         {
@@ -320,31 +245,13 @@
                                 "Unknown"
                             ],
                             "domains": [
-                                "Ketosynthase"
-                            ],
-                            "genes": [
-                                "dfnH"
-                            ],
-                            "module_number": "11",
-                            "non_canonical": {
-                                "evidence": [
-                                    "Structure-based inference"
-                                ],
-                                "iterated": false,
-                                "non_elongating": false,
-                                "skipped": true
-                            }
-                        },
-                        {
-                            "at_specificities": [
-                                "Unknown"
-                            ],
-                            "domains": [
+                                "Ketosynthase",
                                 "Dehydratase",
-                                "Thiolation (ACP/PCP)"
+                                "Dehydratase"
                             ],
                             "genes": [
-                                "dfnI"
+                                "difJ",
+                                "difK"
                             ],
                             "module_number": "11",
                             "non_canonical": {
@@ -363,23 +270,12 @@
                             "domains": [
                                 "Ketosynthase",
                                 "Dehydratase",
-                                "Ketoreductase"
+                                "Thiolation (ACP/PCP)",
+                                "Enoylreductase"
                             ],
                             "genes": [
-                                "dfnI"
-                            ],
-                            "kr_stereochem": "Unknown",
-                            "module_number": "12"
-                        },
-                        {
-                            "at_specificities": [
-                                "Unknown"
-                            ],
-                            "domains": [
-                                "Thiolation (ACP/PCP)"
-                            ],
-                            "genes": [
-                                "dfnJ"
+                                "difK",
+                                "difL"
                             ],
                             "module_number": "12",
                             "pks_mod_doms": [
@@ -391,17 +287,21 @@
                                 "Unknown"
                             ],
                             "domains": [
-                                "Enoylreductase",
                                 "Ketosynthase",
                                 "Thiolation (ACP/PCP)",
                                 "Thioesterase"
                             ],
                             "genes": [
-                                "dfnJ"
+                                "difL"
                             ],
                             "module_number": "13"
                         }
-                    ]
+                    ],
+                    "trans_at": {
+                        "genes": [
+                            "difA"
+                        ]
+                    }
                 }
             ]
         },

--- a/data/BGC0000177.json
+++ b/data/BGC0000177.json
@@ -21,7 +21,8 @@
         },
         {
             "comments": [
-                "Removed ketoreductase stereochemistry annotation from modules without ketoreductases"
+                "Removed ketoreductase stereochemistry annotation from modules without ketoreductases",
+                "Merged cross-CDS PKS modules"
             ],
             "contributors": [
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
@@ -357,22 +358,12 @@
                                 "Unknown"
                             ],
                             "domains": [
-                                "Ketosynthase"
-                            ],
-                            "genes": [
-                                "ACY01390.1"
-                            ],
-                            "module_number": "3"
-                        },
-                        {
-                            "at_specificities": [
-                                "Unknown"
-                            ],
-                            "domains": [
+                                "Ketosynthase",
                                 "Ketoreductase",
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
+                                "ACY01390.1",
                                 "ACY01391.1"
                             ],
                             "kr_stereochem": "Unknown",
@@ -464,10 +455,12 @@
                             ],
                             "domains": [
                                 "Ketosynthase",
-                                "Dehydratase"
+                                "Dehydratase",
+                                "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
-                                "ACY01391.1"
+                                "ACY01391.1",
+                                "ACY01392.1"
                             ],
                             "module_number": "9"
                         },
@@ -486,18 +479,6 @@
                             ],
                             "kr_stereochem": "Unknown",
                             "module_number": "10"
-                        },
-                        {
-                            "at_specificities": [
-                                "Unknown"
-                            ],
-                            "domains": [
-                                "Thiolation (ACP/PCP)"
-                            ],
-                            "genes": [
-                                "ACY01392.1"
-                            ],
-                            "module_number": "9"
                         }
                     ],
                     "subclass": [

--- a/data/BGC0000178.json
+++ b/data/BGC0000178.json
@@ -22,7 +22,8 @@
             "comments": [
                 "Fixed incorrect gene id in annotations",
                 "Remove leading/trailing whitespace in gene identifiers",
-                "Removed ketoreductase stereochemistry annotation from modules without ketoreductases"
+                "Removed ketoreductase stereochemistry annotation from modules without ketoreductases",
+                "Merged cross-CDS PKS modules"
             ],
             "contributors": [
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
@@ -330,22 +331,12 @@
                                 "Unknown"
                             ],
                             "domains": [
-                                "Ketosynthase"
-                            ],
-                            "genes": [
-                                "AEC04356.1"
-                            ],
-                            "module_number": "2"
-                        },
-                        {
-                            "at_specificities": [
-                                "Unknown"
-                            ],
-                            "domains": [
+                                "Ketosynthase",
                                 "Ketoreductase",
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
+                                "AEC04356.1",
                                 "AEC04357.1"
                             ],
                             "kr_stereochem": "D-OH",
@@ -423,23 +414,13 @@
                                 "Unknown"
                             ],
                             "domains": [
-                                "Ketosynthase"
-                            ],
-                            "genes": [
-                                "AEC04361.1"
-                            ],
-                            "module_number": "7"
-                        },
-                        {
-                            "at_specificities": [
-                                "Unknown"
-                            ],
-                            "domains": [
+                                "Ketosynthase",
                                 "Ketoreductase",
                                 "Dehydratase",
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
+                                "AEC04361.1",
                                 "AEC04362.1"
                             ],
                             "kr_stereochem": "D-OH",
@@ -481,24 +462,14 @@
                             "domains": [
                                 "Ketosynthase",
                                 "Ketoreductase",
-                                "Dehydratase"
-                            ],
-                            "genes": [
-                                "AEC04362.1"
-                            ],
-                            "kr_stereochem": "D-OH",
-                            "module_number": "10"
-                        },
-                        {
-                            "at_specificities": [
-                                "Unknown"
-                            ],
-                            "domains": [
+                                "Dehydratase",
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
+                                "AEC04362.1",
                                 "AEC04363.1"
                             ],
+                            "kr_stereochem": "D-OH",
                             "module_number": "10",
                             "pks_mod_doms": [
                                 "Methylation"
@@ -543,23 +514,13 @@
                                 "Unknown"
                             ],
                             "domains": [
-                                "Ketosynthase"
-                            ],
-                            "genes": [
-                                "AEC04363.1"
-                            ],
-                            "module_number": "13"
-                        },
-                        {
-                            "at_specificities": [
-                                "Unknown"
-                            ],
-                            "domains": [
+                                "Ketosynthase",
                                 "Ketoreductase",
                                 "Dehydratase",
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
+                                "AEC04363.1",
                                 "AEC04364.1"
                             ],
                             "kr_stereochem": "D-OH",

--- a/data/BGC0000179.json
+++ b/data/BGC0000179.json
@@ -21,7 +21,8 @@
         },
         {
             "comments": [
-                "Removed ketoreductase stereochemistry annotation from modules without ketoreductases"
+                "Removed ketoreductase stereochemistry annotation from modules without ketoreductases",
+                "Corrected gene identifiers"
             ],
             "contributors": [
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
@@ -75,7 +76,7 @@
                             ]
                         }
                     ],
-                    "id": "CAN93347.1",
+                    "id": "sce3188",
                     "name": "etnD"
                 },
                 {
@@ -113,7 +114,7 @@
                             ]
                         }
                     ],
-                    "id": "CAN93351.1",
+                    "id": "sce3192",
                     "name": "etnH"
                 },
                 {
@@ -168,12 +169,12 @@
                     "genes": [
                         "sce3189",
                         "sce3193",
-                        "ctg1_orf00032",
-                        "CAN93351.1",
+                        "sce3191",
+                        "sce3192",
                         "sce3195",
                         "sce3190",
                         "sce3186",
-                        "CAN93347.1"
+                        "sce3188"
                     ],
                     "modules": [
                         {
@@ -185,7 +186,7 @@
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
-                                "CAN93347.1"
+                                "sce3188"
                             ],
                             "module_number": "1"
                         },
@@ -199,7 +200,7 @@
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
-                                "CAN93347.1"
+                                "sce3188"
                             ],
                             "kr_stereochem": "D-OH",
                             "module_number": "2"
@@ -215,7 +216,7 @@
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
-                                "CAN93347.1"
+                                "sce3188"
                             ],
                             "kr_stereochem": "D-OH",
                             "module_number": "3"
@@ -230,7 +231,7 @@
                                 "Dehydratase"
                             ],
                             "genes": [
-                                "CAN93347.1"
+                                "sce3188"
                             ],
                             "kr_stereochem": "D-OH",
                             "module_number": "4"
@@ -354,7 +355,7 @@
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
-                                "ctg1_orf00032"
+                                "sce3191"
                             ],
                             "kr_stereochem": "D-OH",
                             "module_number": "10"
@@ -369,7 +370,7 @@
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
-                                "ctg1_orf00032"
+                                "sce3191"
                             ],
                             "kr_stereochem": "D-OH",
                             "module_number": "11"
@@ -383,7 +384,7 @@
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
-                                "ctg1_orf00032"
+                                "sce3191"
                             ],
                             "module_number": "12",
                             "pks_mod_doms": [
@@ -400,7 +401,7 @@
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
-                                "ctg1_orf00032"
+                                "sce3191"
                             ],
                             "kr_stereochem": "D-OH",
                             "module_number": "13"
@@ -413,7 +414,7 @@
                                 "Ketosynthase"
                             ],
                             "genes": [
-                                "ctg1_orf00032"
+                                "sce3191"
                             ],
                             "module_number": "14"
                         },
@@ -426,7 +427,7 @@
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
-                                "CAN93351.1"
+                                "sce3192"
                             ],
                             "module_number": "14",
                             "non_canonical": {
@@ -448,7 +449,7 @@
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
-                                "CAN93351.1"
+                                "sce3192"
                             ],
                             "kr_stereochem": "D-OH",
                             "module_number": "15"
@@ -464,7 +465,7 @@
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
-                                "CAN93351.1"
+                                "sce3192"
                             ],
                             "kr_stereochem": "D-OH",
                             "module_number": "16",

--- a/data/BGC0000179.json
+++ b/data/BGC0000179.json
@@ -22,7 +22,8 @@
         {
             "comments": [
                 "Removed ketoreductase stereochemistry annotation from modules without ketoreductases",
-                "Corrected gene identifiers"
+                "Corrected gene identifiers",
+                "Merged cross-CDS PKS modules"
             ],
             "contributors": [
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
@@ -228,24 +229,14 @@
                             "domains": [
                                 "Ketosynthase",
                                 "Ketoreductase",
-                                "Dehydratase"
-                            ],
-                            "genes": [
-                                "sce3188"
-                            ],
-                            "kr_stereochem": "D-OH",
-                            "module_number": "4"
-                        },
-                        {
-                            "at_specificities": [
-                                "Unknown"
-                            ],
-                            "domains": [
+                                "Dehydratase",
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
+                                "sce3188",
                                 "sce3189"
                             ],
+                            "kr_stereochem": "D-OH",
                             "module_number": "4"
                         },
                         {
@@ -283,24 +274,14 @@
                             ],
                             "domains": [
                                 "Ketosynthase",
-                                "Ketoreductase"
-                            ],
-                            "genes": [
-                                "sce3189"
-                            ],
-                            "kr_stereochem": "D-OH",
-                            "module_number": "7"
-                        },
-                        {
-                            "at_specificities": [
-                                "Unknown"
-                            ],
-                            "domains": [
+                                "Ketoreductase",
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
+                                "sce3189",
                                 "sce3190"
                             ],
+                            "kr_stereochem": "D-OH",
                             "module_number": "7"
                         },
                         {
@@ -338,23 +319,13 @@
                                 "Unknown"
                             ],
                             "domains": [
-                                "Ketosynthase"
-                            ],
-                            "genes": [
-                                "sce3190"
-                            ],
-                            "module_number": "10"
-                        },
-                        {
-                            "at_specificities": [
-                                "Unknown"
-                            ],
-                            "domains": [
+                                "Ketosynthase",
                                 "Ketoreductase",
                                 "Dehydratase",
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
+                                "sce3190",
                                 "sce3191"
                             ],
                             "kr_stereochem": "D-OH",
@@ -411,22 +382,12 @@
                                 "Unknown"
                             ],
                             "domains": [
-                                "Ketosynthase"
-                            ],
-                            "genes": [
-                                "sce3191"
-                            ],
-                            "module_number": "14"
-                        },
-                        {
-                            "at_specificities": [
-                                "Unknown"
-                            ],
-                            "domains": [
+                                "Ketosynthase",
                                 "Dehydratase",
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
+                                "sce3191",
                                 "sce3192"
                             ],
                             "module_number": "14",
@@ -462,28 +423,18 @@
                                 "Ketosynthase",
                                 "Ketoreductase",
                                 "Dehydratase",
-                                "Thiolation (ACP/PCP)"
+                                "Thiolation (ACP/PCP)",
+                                "Enoylreductase"
                             ],
                             "genes": [
-                                "sce3192"
+                                "sce3192",
+                                "sce3193"
                             ],
                             "kr_stereochem": "D-OH",
                             "module_number": "16",
                             "pks_mod_doms": [
                                 "Methylation"
                             ]
-                        },
-                        {
-                            "at_specificities": [
-                                "Unknown"
-                            ],
-                            "domains": [
-                                "Enoylreductase"
-                            ],
-                            "genes": [
-                                "sce3193"
-                            ],
-                            "module_number": "16"
                         },
                         {
                             "at_specificities": [

--- a/data/BGC0000179.json
+++ b/data/BGC0000179.json
@@ -23,7 +23,8 @@
             "comments": [
                 "Removed ketoreductase stereochemistry annotation from modules without ketoreductases",
                 "Corrected gene identifiers",
-                "Merged cross-CDS PKS modules"
+                "Merged cross-CDS PKS modules",
+                "Corrected PKS module 11 activity based on reference paper"
             ],
             "contributors": [
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
@@ -344,7 +345,15 @@
                                 "sce3191"
                             ],
                             "kr_stereochem": "D-OH",
-                            "module_number": "11"
+                            "module_number": "11",
+                            "non_canonical": {
+                                "evidence": [
+                                    "Structure-based inference"
+                                ],
+                                "iterated": false,
+                                "non_elongating": false,
+                                "skipped": true
+                            }
                         },
                         {
                             "at_specificities": [

--- a/data/BGC0000181.json
+++ b/data/BGC0000181.json
@@ -21,7 +21,8 @@
         },
         {
             "comments": [
-                "Removed ketoreductase stereochemistry annotation from modules without ketoreductases"
+                "Removed ketoreductase stereochemistry annotation from modules without ketoreductases",
+                "Merged cross-CDS PKS modules"
             ],
             "contributors": [
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
@@ -127,22 +128,12 @@
                             ],
                             "domains": [
                                 "Ketosynthase",
-                                "Dehydratase"
-                            ],
-                            "genes": [
-                                "YP001421028"
-                            ],
-                            "module_number": "3"
-                        },
-                        {
-                            "at_specificities": [
-                                "Unknown"
-                            ],
-                            "domains": [
+                                "Dehydratase",
                                 "Ketoreductase",
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
+                                "YP001421028",
                                 "YP001421029"
                             ],
                             "kr_stereochem": "Unknown",
@@ -154,22 +145,12 @@
                             ],
                             "domains": [
                                 "Ketosynthase",
-                                "Dehydratase"
-                            ],
-                            "genes": [
-                                "YP001421029"
-                            ],
-                            "module_number": "4"
-                        },
-                        {
-                            "at_specificities": [
-                                "Unknown"
-                            ],
-                            "domains": [
+                                "Dehydratase",
                                 "Ketoreductase",
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
+                                "YP001421029",
                                 "YP001421030"
                             ],
                             "kr_stereochem": "Unknown",
@@ -196,22 +177,12 @@
                             ],
                             "domains": [
                                 "Ketosynthase",
-                                "Thiolation (ACP/PCP)"
-                            ],
-                            "genes": [
-                                "YP001421030"
-                            ],
-                            "module_number": "6"
-                        },
-                        {
-                            "at_specificities": [
-                                "Unknown"
-                            ],
-                            "domains": [
+                                "Thiolation (ACP/PCP)",
                                 "Ketoreductase",
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
+                                "YP001421030",
                                 "YP001421031"
                             ],
                             "kr_stereochem": "Unknown",
@@ -237,23 +208,13 @@
                                 "Unknown"
                             ],
                             "domains": [
-                                "Ketosynthase"
-                            ],
-                            "genes": [
-                                "YP001421031"
-                            ],
-                            "module_number": "8"
-                        },
-                        {
-                            "at_specificities": [
-                                "Unknown"
-                            ],
-                            "domains": [
+                                "Ketosynthase",
                                 "Dehydratase",
                                 "Thiolation (ACP/PCP)",
                                 "Ketoreductase"
                             ],
                             "genes": [
+                                "YP001421031",
                                 "YP001421032"
                             ],
                             "kr_stereochem": "Unknown",
@@ -264,11 +225,15 @@
                                 "Unknown"
                             ],
                             "domains": [
-                                "Ketosynthase"
+                                "Ketosynthase",
+                                "Ketoreductase",
+                                "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
-                                "YP001421032"
+                                "YP001421032",
+                                "YP001421033"
                             ],
+                            "kr_stereochem": "Unknown",
                             "module_number": "9"
                         },
                         {
@@ -292,32 +257,7 @@
                                 "Unknown"
                             ],
                             "domains": [
-                                "Ketosynthase"
-                            ],
-                            "genes": [
-                                "YP001421033"
-                            ],
-                            "module_number": "11"
-                        },
-                        {
-                            "at_specificities": [
-                                "Unknown"
-                            ],
-                            "domains": [
-                                "Ketoreductase",
-                                "Thiolation (ACP/PCP)"
-                            ],
-                            "genes": [
-                                "YP001421033"
-                            ],
-                            "kr_stereochem": "Unknown",
-                            "module_number": "9"
-                        },
-                        {
-                            "at_specificities": [
-                                "Unknown"
-                            ],
-                            "domains": [
+                                "Ketosynthase",
                                 "Dehydratase",
                                 "Thiolation (ACP/PCP)",
                                 "Thiolation (ACP/PCP)",
@@ -325,6 +265,7 @@
                                 "Thioesterase"
                             ],
                             "genes": [
+                                "YP001421033",
                                 "YP001421034"
                             ],
                             "kr_stereochem": "Unknown",

--- a/data/BGC0000184.json
+++ b/data/BGC0000184.json
@@ -21,7 +21,8 @@
         },
         {
             "comments": [
-                "Removed ketoreductase stereochemistry annotation from modules without ketoreductases"
+                "Removed ketoreductase stereochemistry annotation from modules without ketoreductases",
+                "Merged cross-CDS PKS modules"
             ],
             "contributors": [
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
@@ -304,22 +305,12 @@
                                 "Unknown"
                             ],
                             "domains": [
-                                "Ketosynthase"
-                            ],
-                            "genes": [
-                                "ADN68476.1"
-                            ],
-                            "module_number": "7"
-                        },
-                        {
-                            "at_specificities": [
-                                "Unknown"
-                            ],
-                            "domains": [
+                                "Ketosynthase",
                                 "Dehydratase",
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
+                                "ADN68476.1",
                                 "ADN68477.1"
                             ],
                             "module_number": "7"
@@ -373,22 +364,12 @@
                                 "Unknown"
                             ],
                             "domains": [
-                                "Ketosynthase"
-                            ],
-                            "genes": [
-                                "ADN68477.1"
-                            ],
-                            "module_number": "11"
-                        },
-                        {
-                            "at_specificities": [
-                                "Unknown"
-                            ],
-                            "domains": [
+                                "Ketosynthase",
                                 "Dehydratase",
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
+                                "ADN68477.1",
                                 "ADN68478.1"
                             ],
                             "module_number": "11"
@@ -399,24 +380,14 @@
                             ],
                             "domains": [
                                 "Ketosynthase",
-                                "Ketoreductase"
-                            ],
-                            "genes": [
-                                "ADN68478.1"
-                            ],
-                            "kr_stereochem": "D-OH",
-                            "module_number": "12"
-                        },
-                        {
-                            "at_specificities": [
-                                "Unknown"
-                            ],
-                            "domains": [
+                                "Ketoreductase",
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
+                                "ADN68478.1",
                                 "ADN68479.1"
                             ],
+                            "kr_stereochem": "D-OH",
                             "module_number": "12",
                             "pks_mod_doms": [
                                 "Methylation"
@@ -443,24 +414,14 @@
                             ],
                             "domains": [
                                 "Ketosynthase",
-                                "Ketoreductase"
-                            ],
-                            "genes": [
-                                "ADN68479.1"
-                            ],
-                            "kr_stereochem": "D-OH",
-                            "module_number": "14"
-                        },
-                        {
-                            "at_specificities": [
-                                "Unknown"
-                            ],
-                            "domains": [
+                                "Ketoreductase",
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
+                                "ADN68479.1",
                                 "ADN68480.1"
                             ],
+                            "kr_stereochem": "D-OH",
                             "module_number": "14",
                             "pks_mod_doms": [
                                 "Methylation"
@@ -505,24 +466,14 @@
                             "domains": [
                                 "Ketosynthase",
                                 "Ketoreductase",
-                                "Dehydratase"
-                            ],
-                            "genes": [
-                                "ADN68480.1"
-                            ],
-                            "kr_stereochem": "D-OH",
-                            "module_number": "17"
-                        },
-                        {
-                            "at_specificities": [
-                                "Unknown"
-                            ],
-                            "domains": [
+                                "Dehydratase",
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
+                                "ADN68480.1",
                                 "ADN68482.1"
                             ],
+                            "kr_stereochem": "D-OH",
                             "module_number": "17",
                             "pks_mod_doms": [
                                 "Methylation"
@@ -547,22 +498,12 @@
                             ],
                             "domains": [
                                 "Ketosynthase",
-                                "Dehydratase"
-                            ],
-                            "genes": [
-                                "ADN68482.1"
-                            ],
-                            "module_number": "19"
-                        },
-                        {
-                            "at_specificities": [
-                                "Unknown"
-                            ],
-                            "domains": [
+                                "Dehydratase",
                                 "Ketoreductase",
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
+                                "ADN68482.1",
                                 "ADN68483.1"
                             ],
                             "kr_stereochem": "D-OH",
@@ -604,22 +545,12 @@
                                 "Unknown"
                             ],
                             "domains": [
-                                "Ketosynthase"
-                            ],
-                            "genes": [
-                                "ADN68483.1"
-                            ],
-                            "module_number": "22"
-                        },
-                        {
-                            "at_specificities": [
-                                "Unknown"
-                            ],
-                            "domains": [
+                                "Ketosynthase",
                                 "Dehydratase",
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
+                                "ADN68483.1",
                                 "ADN68484.1"
                             ],
                             "module_number": "22"

--- a/data/BGC0000227.json
+++ b/data/BGC0000227.json
@@ -21,7 +21,8 @@
         {
             "comments": [
                 "Remove negative ketide_length",
-                "Removed ketoreductase stereochemistry annotation from modules without ketoreductases"
+                "Removed ketoreductase stereochemistry annotation from modules without ketoreductases",
+                "Removed module fragments from Type II polyketide synthase"
             ],
             "contributors": [
                 "3UOU7PODQJXIM6BEPUHHRRA5",
@@ -69,45 +70,6 @@
                         "CAA09654.1",
                         "CAA09655.1",
                         "CAA09653.1"
-                    ],
-                    "modules": [
-                        {
-                            "at_specificities": [
-                                "Unknown"
-                            ],
-                            "domains": [
-                                "Ketosynthase"
-                            ],
-                            "genes": [
-                                "CAA09653.1"
-                            ],
-                            "module_number": "0"
-                        },
-                        {
-                            "at_specificities": [
-                                "Malonyl-CoA"
-                            ],
-                            "domains": [
-                                "CoA-ligase"
-                            ],
-                            "evidence": "Sequence-based prediction",
-                            "genes": [
-                                "CAA09654.1"
-                            ],
-                            "module_number": "1"
-                        },
-                        {
-                            "at_specificities": [
-                                "Unknown"
-                            ],
-                            "domains": [
-                                "Thiolation (ACP/PCP)"
-                            ],
-                            "genes": [
-                                "CAA09655.1"
-                            ],
-                            "module_number": "1"
-                        }
                     ],
                     "subclass": [
                         "Type II"

--- a/data/BGC0000429.json
+++ b/data/BGC0000429.json
@@ -26,7 +26,8 @@
                 "Corrected NRP module activity",
                 "Removed gene names of 'No gene ID'",
                 "Removed duplicate gene names",
-                "Removed ketoreductase stereochemistry annotation from modules without ketoreductases"
+                "Removed ketoreductase stereochemistry annotation from modules without ketoreductases",
+                "Removed module numbers from incomplete PKS modules"
             ],
             "contributors": [
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
@@ -931,8 +932,7 @@
                             ],
                             "genes": [
                                 "AEA30256.1"
-                            ],
-                            "module_number": "0"
+                            ]
                         },
                         {
                             "at_specificities": [
@@ -943,8 +943,7 @@
                             ],
                             "genes": [
                                 "AEA30260.1"
-                            ],
-                            "module_number": "0"
+                            ]
                         },
                         {
                             "at_specificities": [
@@ -955,8 +954,7 @@
                             ],
                             "genes": [
                                 "AEA30261.1"
-                            ],
-                            "module_number": "0"
+                            ]
                         },
                         {
                             "at_specificities": [
@@ -967,8 +965,7 @@
                             ],
                             "genes": [
                                 "AEA30262.1"
-                            ],
-                            "module_number": "0"
+                            ]
                         }
                     ]
                 }

--- a/data/BGC0000958.json
+++ b/data/BGC0000958.json
@@ -21,7 +21,8 @@
         {
             "comments": [
                 "Corrected NRP module activity",
-                "Removed ketoreductase stereochemistry annotation from modules without ketoreductases"
+                "Removed ketoreductase stereochemistry annotation from modules without ketoreductases",
+                "Reworked NRPS/PKS modules to match reference papers"
             ],
             "contributors": [
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
@@ -98,26 +99,7 @@
             "cyclic": true,
             "nrps_genes": [
                 {
-                    "gene_id": "ZP_09179982.1",
-                    "modules": [
-                        {
-                            "active": true,
-                            "c_dom_subtype": "Starter",
-                            "module_number": "0"
-                        }
-                    ]
-                },
-                {
-                    "gene_id": "ZP_09179983.1",
-                    "modules": [
-                        {
-                            "active": true,
-                            "module_number": "0"
-                        }
-                    ]
-                },
-                {
-                    "gene_id": "ZP_09179979.1",
+                    "gene_id": "WP_010639240.1",
                     "modules": [
                         {
                             "a_substr_spec": {
@@ -167,8 +149,7 @@
             "synthases": [
                 {
                     "genes": [
-                        "ZP_09179989.1",
-                        "ZP_09179980.1"
+                        "WP_010639241.1"
                     ],
                     "modules": [
                         {
@@ -183,21 +164,8 @@
                             ],
                             "evidence": "Activity assay",
                             "genes": [
-                                "ZP_09179980.1"
+                                "WP_010639241.1"
                             ],
-                            "module_number": "3"
-                        },
-                        {
-                            "at_specificities": [
-                                "Unknown"
-                            ],
-                            "domains": [
-                                "Ketoreductase"
-                            ],
-                            "genes": [
-                                "ZP_09179989.1"
-                            ],
-                            "kr_stereochem": "Unknown",
                             "module_number": "3"
                         }
                     ],

--- a/data/BGC0000967.json
+++ b/data/BGC0000967.json
@@ -22,7 +22,8 @@
         {
             "comments": [
                 "Corrected NRP module activity",
-                "Removed ketoreductase stereochemistry annotation from modules without ketoreductases"
+                "Removed ketoreductase stereochemistry annotation from modules without ketoreductases",
+                "Merged cross-CDS PKS modules"
             ],
             "contributors": [
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
@@ -940,26 +941,15 @@
                             ],
                             "domains": [
                                 "Ketosynthase",
-                                "Ketoreductase"
-                            ],
-                            "evidence": "Sequence-based prediction",
-                            "genes": [
-                                "BAP05594.1"
-                            ],
-                            "kr_stereochem": "Unknown",
-                            "module_number": "23"
-                        },
-                        {
-                            "at_specificities": [
-                                "Unknown"
-                            ],
-                            "domains": [
+                                "Ketoreductase",
                                 "Thiolation (ACP/PCP)"
                             ],
                             "evidence": "Sequence-based prediction",
                             "genes": [
+                                "BAP05594.1",
                                 "BAP05595.1"
                             ],
+                            "kr_stereochem": "Unknown",
                             "module_number": "23",
                             "pks_mod_doms": [
                                 "Methylation"
@@ -1077,30 +1067,19 @@
                                 "Unknown"
                             ],
                             "domains": [
-                                "Ketosynthase"
-                            ],
-                            "evidence": "Sequence-based prediction",
-                            "genes": [
-                                "BAP05596.1"
-                            ],
-                            "module_number": "31",
-                            "pks_mod_doms": [
-                                "Beta-branching"
-                            ]
-                        },
-                        {
-                            "at_specificities": [
-                                "Unknown"
-                            ],
-                            "domains": [
+                                "Ketosynthase",
                                 "Dehydratase",
                                 "Thiolation (ACP/PCP)"
                             ],
                             "evidence": "Sequence-based prediction",
                             "genes": [
+                                "BAP05596.1",
                                 "BAP05597.1"
                             ],
-                            "module_number": "31"
+                            "module_number": "31",
+                            "pks_mod_doms": [
+                                "Beta-branching"
+                            ]
                         },
                         {
                             "at_specificities": [

--- a/data/BGC0001025.json
+++ b/data/BGC0001025.json
@@ -21,7 +21,8 @@
         },
         {
             "comments": [
-                "Removed ketoreductase stereochemistry annotation from modules without ketoreductases"
+                "Removed ketoreductase stereochemistry annotation from modules without ketoreductases",
+                "Changed gene identifiers to consistently use locus tag instead of a mix of locus and protein ID"
             ],
             "contributors": [
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
@@ -56,7 +57,7 @@
                             ]
                         }
                     ],
-                    "id": "ABF85931.1",
+                    "id": "MXAN_3935",
                     "name": "Ta1"
                 },
                 {
@@ -81,7 +82,7 @@
                             ]
                         }
                     ],
-                    "id": "ABF90753.1",
+                    "id": "MXAN_3949",
                     "name": "taB",
                     "product": "acyl-carrier protein"
                 },
@@ -94,7 +95,7 @@
                             ]
                         }
                     ],
-                    "id": "ABF90176.1",
+                    "id": "MXAN_3948",
                     "name": "taC",
                     "product": "HMGCoA synthase",
                     "tailoring": [
@@ -123,7 +124,7 @@
                             ]
                         }
                     ],
-                    "id": "ABF92623.1",
+                    "id": "MXAN_3945",
                     "name": "taF",
                     "product": "HMGCoA synthase",
                     "tailoring": [
@@ -139,7 +140,7 @@
                             ]
                         }
                     ],
-                    "id": "ABF86324.1",
+                    "id": "MXAN_3943",
                     "name": "taH",
                     "product": "cytochrome P450",
                     "tailoring": [
@@ -155,7 +156,7 @@
                             ]
                         }
                     ],
-                    "id": "ABF89568.1",
+                    "id": "MXAN_3938",
                     "name": "taI"
                 },
                 {
@@ -195,7 +196,7 @@
                             ]
                         }
                     ],
-                    "id": "ABF92824.1",
+                    "id": "MXAN_3936",
                     "name": "taL"
                 },
                 {
@@ -234,7 +235,7 @@
                             ]
                         }
                     ],
-                    "id": "ABF88102.1",
+                    "id": "MXAN_3932",
                     "name": "taP"
                 },
                 {
@@ -246,7 +247,7 @@
                             ]
                         }
                     ],
-                    "id": "ABF89350.1",
+                    "id": "MXAN_3931",
                     "name": "taQ",
                     "product": "methyltransferase",
                     "tailoring": [
@@ -262,7 +263,7 @@
                             ]
                         }
                     ],
-                    "id": "ABF91606.1",
+                    "id": "MXAN_3942",
                     "name": "taV"
                 },
                 {
@@ -274,7 +275,7 @@
                             ]
                         }
                     ],
-                    "id": "ABF86745.1",
+                    "id": "MXAN_3940",
                     "name": "taX",
                     "tailoring": [
                         "Unknown"
@@ -289,7 +290,7 @@
                             ]
                         }
                     ],
-                    "id": "ABF92581.1",
+                    "id": "MXAN_3939",
                     "name": "taY",
                     "product": "\"putative enoyl-CoA-hydratase",
                     "tailoring": [
@@ -328,10 +329,10 @@
             "synthases": [
                 {
                     "genes": [
-                        "ABF85931.1",
+                        "MXAN_3935",
                         "MXAN_3933",
-                        "ABF91606.1",
-                        "ABF88102.1"
+                        "MXAN_3942",
+                        "MXAN_3932"
                     ],
                     "modules": [
                         {
@@ -345,7 +346,7 @@
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
-                                "ABF85931.1"
+                                "MXAN_3935"
                             ],
                             "kr_stereochem": "D-OH",
                             "module_number": "1"
@@ -360,7 +361,7 @@
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
-                                "ABF85931.1"
+                                "MXAN_3935"
                             ],
                             "kr_stereochem": "L-OH",
                             "module_number": "2"
@@ -374,7 +375,7 @@
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
-                                "ABF85931.1"
+                                "MXAN_3935"
                             ],
                             "module_number": "3"
                         },
@@ -389,7 +390,7 @@
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
-                                "ABF85931.1"
+                                "MXAN_3935"
                             ],
                             "kr_stereochem": "D-OH",
                             "module_number": "4"
@@ -403,7 +404,7 @@
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
-                                "ABF85931.1"
+                                "MXAN_3935"
                             ],
                             "module_number": "5"
                         },
@@ -418,7 +419,7 @@
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
-                                "ABF85931.1"
+                                "MXAN_3935"
                             ],
                             "kr_stereochem": "D-OH",
                             "module_number": "6"
@@ -432,7 +433,7 @@
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
-                                "ABF85931.1"
+                                "MXAN_3935"
                             ],
                             "module_number": "7"
                         },
@@ -505,7 +506,7 @@
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
-                                "ABF88102.1"
+                                "MXAN_3932"
                             ],
                             "module_number": "11"
                         },
@@ -521,7 +522,7 @@
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
-                                "ABF88102.1"
+                                "MXAN_3932"
                             ],
                             "kr_stereochem": "D-OH",
                             "module_number": "12",
@@ -535,7 +536,7 @@
                     ],
                     "trans_at": {
                         "genes": [
-                            "ABF91606.1"
+                            "MXAN_3942"
                         ]
                     }
                 }

--- a/data/BGC0001025.json
+++ b/data/BGC0001025.json
@@ -22,7 +22,8 @@
         {
             "comments": [
                 "Removed ketoreductase stereochemistry annotation from modules without ketoreductases",
-                "Changed gene identifiers to consistently use locus tag instead of a mix of locus and protein ID"
+                "Changed gene identifiers to consistently use locus tag instead of a mix of locus and protein ID",
+                "Merged cross-CDS PKS modules"
             ],
             "contributors": [
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
@@ -488,27 +489,17 @@
                                 "Unknown"
                             ],
                             "domains": [
-                                "Ketosynthase"
+                                "Ketosynthase",
+                                "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
-                                "MXAN_3933"
+                                "MXAN_3933",
+                                "MXAN_3932"
                             ],
                             "module_number": "11",
                             "pks_mod_doms": [
                                 "Methylation"
                             ]
-                        },
-                        {
-                            "at_specificities": [
-                                "Unknown"
-                            ],
-                            "domains": [
-                                "Thiolation (ACP/PCP)"
-                            ],
-                            "genes": [
-                                "MXAN_3932"
-                            ],
-                            "module_number": "11"
                         },
                         {
                             "at_specificities": [

--- a/data/BGC0001069.json
+++ b/data/BGC0001069.json
@@ -22,7 +22,8 @@
         {
             "comments": [
                 "Corrected NRP module activity",
-                "Removed ketoreductase stereochemistry annotation from modules without ketoreductases"
+                "Removed ketoreductase stereochemistry annotation from modules without ketoreductases",
+                "Merged cross-CDS PKS modules"
             ],
             "contributors": [
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
@@ -358,23 +359,13 @@
                                 "Unknown"
                             ],
                             "domains": [
-                                "Ketosynthase"
-                            ],
-                            "genes": [
-                                "AAY89051.1"
-                            ],
-                            "module_number": "11"
-                        },
-                        {
-                            "at_specificities": [
-                                "Unknown"
-                            ],
-                            "domains": [
+                                "Ketosynthase",
                                 "Ketoreductase",
                                 "Dehydratase",
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
+                                "AAY89051.1",
                                 "AAY89052.1"
                             ],
                             "kr_stereochem": "D-OH",

--- a/data/BGC0001070.json
+++ b/data/BGC0001070.json
@@ -22,7 +22,8 @@
             "comments": [
                 "Corrected NRP module activity",
                 "Removed duplicate gene annotation",
-                "Removed ketoreductase stereochemistry annotation from modules without ketoreductases"
+                "Removed ketoreductase stereochemistry annotation from modules without ketoreductases",
+                "Merged cross-CDS PKS modules"
             ],
             "contributors": [
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
@@ -217,23 +218,13 @@
                                 "Unknown"
                             ],
                             "domains": [
-                                "Ketosynthase"
-                            ],
-                            "genes": [
-                                "CAN89631.1"
-                            ],
-                            "module_number": "2"
-                        },
-                        {
-                            "at_specificities": [
-                                "Unknown"
-                            ],
-                            "domains": [
+                                "Ketosynthase",
                                 "Ketoreductase",
                                 "Dehydratase",
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
+                                "CAN89631.1",
                                 "CAN89632.1"
                             ],
                             "kr_stereochem": "L-OH",
@@ -290,23 +281,13 @@
                                 "Unknown"
                             ],
                             "domains": [
-                                "Ketosynthase"
-                            ],
-                            "genes": [
-                                "CAN89633.1"
-                            ],
-                            "module_number": "7"
-                        },
-                        {
-                            "at_specificities": [
-                                "Unknown"
-                            ],
-                            "domains": [
+                                "Ketosynthase",
                                 "Ketoreductase",
                                 "Dehydratase",
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
+                                "CAN89633.1",
                                 "CAN89634.1"
                             ],
                             "kr_stereochem": "D-OH",
@@ -379,23 +360,13 @@
                                 "Unknown"
                             ],
                             "domains": [
-                                "Ketosynthase"
-                            ],
-                            "genes": [
-                                "CAN89634.1"
-                            ],
-                            "module_number": "12"
-                        },
-                        {
-                            "at_specificities": [
-                                "Unknown"
-                            ],
-                            "domains": [
+                                "Ketosynthase",
                                 "Ketoreductase",
                                 "Dehydratase",
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
+                                "CAN89634.1",
                                 "CAN89635.1"
                             ],
                             "kr_stereochem": "L-OH",

--- a/data/BGC0001089.json
+++ b/data/BGC0001089.json
@@ -23,7 +23,8 @@
                 "Linked new PubChem id for bacillaene (pubchem:25144999)",
                 "Corrected NRP module activity",
                 "Changed annotations to use correct gene idenitifers",
-                "Removed ketoreductase stereochemistry annotation from modules without ketoreductases"
+                "Removed ketoreductase stereochemistry annotation from modules without ketoreductases",
+                "Merged cross-CDS PKS modules and corrected others"
             ],
             "contributors": [
                 "5UL74VURKJ25VSPPPO3H2NYB",
@@ -332,10 +333,13 @@
                                 "Unknown"
                             ],
                             "domains": [
-                                "Ketosynthase"
+                                "Ketosynthase",
+                                "Dehydratase",
+                                "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
-                                "baeJ"
+                                "baeJ",
+                                "baeL"
                             ],
                             "module_number": "4",
                             "non_canonical": {
@@ -343,22 +347,9 @@
                                     "Sequence-based prediction"
                                 ],
                                 "iterated": false,
-                                "non_elongating": false,
-                                "skipped": true
+                                "non_elongating": true,
+                                "skipped": false
                             }
-                        },
-                        {
-                            "at_specificities": [
-                                "Unknown"
-                            ],
-                            "domains": [
-                                "Dehydratase",
-                                "Thiolation (ACP/PCP)"
-                            ],
-                            "genes": [
-                                "baeL"
-                            ],
-                            "module_number": "4"
                         },
                         {
                             "at_specificities": [
@@ -421,8 +412,8 @@
                                     "Structure-based inference"
                                 ],
                                 "iterated": false,
-                                "non_elongating": false,
-                                "skipped": true
+                                "non_elongating": true,
+                                "skipped": false
                             }
                         },
                         {
@@ -498,25 +489,15 @@
                             "domains": [
                                 "Ketosynthase",
                                 "Dehydratase",
-                                "Ketoreductase"
-                            ],
-                            "genes": [
-                                "baeN"
-                            ],
-                            "kr_stereochem": "Unknown",
-                            "module_number": "14"
-                        },
-                        {
-                            "at_specificities": [
-                                "Unknown"
-                            ],
-                            "domains": [
+                                "Ketoreductase",
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
+                                "baeN",
                                 "baeR"
                             ],
-                            "module_number": "15",
+                            "kr_stereochem": "Unknown",
+                            "module_number": "14",
                             "pks_mod_doms": [
                                 "Methylation"
                             ]
@@ -533,7 +514,7 @@
                             "genes": [
                                 "baeR"
                             ],
-                            "module_number": "16",
+                            "module_number": "15",
                             "non_canonical": {
                                 "evidence": [
                                     "Structure-based inference"
@@ -555,7 +536,7 @@
                             "genes": [
                                 "baeR"
                             ],
-                            "module_number": "17",
+                            "module_number": "16",
                             "non_canonical": {
                                 "evidence": [
                                     "Structure-based inference"

--- a/data/BGC0001101.json
+++ b/data/BGC0001101.json
@@ -21,7 +21,8 @@
         {
             "comments": [
                 "Corrected NRP module activity",
-                "Removed ketoreductase stereochemistry annotation from modules without ketoreductases"
+                "Removed ketoreductase stereochemistry annotation from modules without ketoreductases",
+                "Merged cross-CDS PKS modules"
             ],
             "contributors": [
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
@@ -485,23 +486,13 @@
                                 "Unknown"
                             ],
                             "domains": [
-                                "Ketosynthase"
-                            ],
-                            "genes": [
-                                "AAN85522.1"
-                            ],
-                            "module_number": "3"
-                        },
-                        {
-                            "at_specificities": [
-                                "Unknown"
-                            ],
-                            "domains": [
+                                "Ketosynthase",
                                 "Dehydratase",
                                 "Thiolation (ACP/PCP)",
                                 "Ketoreductase"
                             ],
                             "genes": [
+                                "AAN85522.1",
                                 "AAN85523.1"
                             ],
                             "kr_stereochem": "Unknown",

--- a/data/BGC0001105.json
+++ b/data/BGC0001105.json
@@ -22,7 +22,8 @@
             "comments": [
                 "Update compound structure (SMILES) for onnamide A",
                 "Corrected NRP module activity",
-                "Removed ketoreductase stereochemistry annotation from modules without ketoreductases"
+                "Removed ketoreductase stereochemistry annotation from modules without ketoreductases",
+                "Removed invalid PKS modules"
             ],
             "contributors": [
                 "5UL74VURKJ25VSPPPO3H2NYB",
@@ -129,8 +130,7 @@
                 {
                     "genes": [
                         "AAV97877.1",
-                        "AAV97870.1",
-                        "no accession available"
+                        "AAV97870.1"
                     ],
                     "modules": [
                         {
@@ -305,48 +305,6 @@
                             ],
                             "kr_stereochem": "L-OH",
                             "module_number": "9"
-                        },
-                        {
-                            "at_specificities": [
-                                "Unknown"
-                            ],
-                            "domains": [
-                                "Dehydratase",
-                                "Thiolation (ACP/PCP)"
-                            ],
-                            "genes": [
-                                "no accession available"
-                            ],
-                            "module_number": "11"
-                        },
-                        {
-                            "at_specificities": [
-                                "Unknown"
-                            ],
-                            "domains": [
-                                "Ketosynthase",
-                                "Dehydratase",
-                                "Thiolation (ACP/PCP)"
-                            ],
-                            "genes": [
-                                "no accession available"
-                            ],
-                            "module_number": "12"
-                        },
-                        {
-                            "at_specificities": [
-                                "Unknown"
-                            ],
-                            "domains": [
-                                "Ketosynthase",
-                                "Ketoreductase",
-                                "Thiolation (ACP/PCP)"
-                            ],
-                            "genes": [
-                                "no accession available"
-                            ],
-                            "kr_stereochem": "D-OH",
-                            "module_number": "13"
                         }
                     ],
                     "subclass": [

--- a/data/BGC0001111.json
+++ b/data/BGC0001111.json
@@ -23,7 +23,8 @@
             "comments": [
                 "Corrected NRP module activity",
                 "Remove leading/trailing whitespace in gene identifiers",
-                "Removed ketoreductase stereochemistry annotation from modules without ketoreductases"
+                "Removed ketoreductase stereochemistry annotation from modules without ketoreductases",
+                "Merged cross-CDS PKS modules"
             ],
             "contributors": [
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
@@ -330,28 +331,18 @@
                             ],
                             "domains": [
                                 "Ketosynthase",
-                                "Ketoreductase"
+                                "Ketoreductase",
+                                "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
-                                "CCA89326.1"
+                                "CCA89326.1",
+                                "CCA89327.1"
                             ],
                             "kr_stereochem": "D-OH",
                             "module_number": "9",
                             "pks_mod_doms": [
                                 "Methylation"
                             ]
-                        },
-                        {
-                            "at_specificities": [
-                                "Unknown"
-                            ],
-                            "domains": [
-                                "Thiolation (ACP/PCP)"
-                            ],
-                            "genes": [
-                                "CCA89327.1"
-                            ],
-                            "module_number": "9"
                         },
                         {
                             "at_specificities": [
@@ -460,22 +451,12 @@
                                 "Unknown"
                             ],
                             "domains": [
-                                "Ketosynthase"
-                            ],
-                            "genes": [
-                                "CCA89328.1"
-                            ],
-                            "module_number": "18"
-                        },
-                        {
-                            "at_specificities": [
-                                "Unknown"
-                            ],
-                            "domains": [
+                                "Ketosynthase",
                                 "Ketoreductase",
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
+                                "CCA89328.1",
                                 "CCA89329.1"
                             ],
                             "kr_stereochem": "D-OH",

--- a/data/BGC0001112.json
+++ b/data/BGC0001112.json
@@ -22,7 +22,8 @@
             "comments": [
                 "Corrected NRP module activity",
                 "Corrected polyketide synthase gene entries",
-                "Removed ketoreductase stereochemistry annotation from modules without ketoreductases"
+                "Removed ketoreductase stereochemistry annotation from modules without ketoreductases",
+                "Merged cross-CDS PKS modules"
             ],
             "contributors": [
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
@@ -203,24 +204,14 @@
                             "domains": [
                                 "Ketosynthase",
                                 "Dehydratase",
-                                "Ketoreductase"
-                            ],
-                            "genes": [
-                                "rhiB"
-                            ],
-                            "kr_stereochem": "L-OH",
-                            "module_number": "3"
-                        },
-                        {
-                            "at_specificities": [
-                                "Unknown"
-                            ],
-                            "domains": [
+                                "Ketoreductase",
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
+                                "rhiB",
                                 "rhiC"
                             ],
+                            "kr_stereochem": "L-OH",
                             "module_number": "3",
                             "pks_mod_doms": [
                                 "Methylation"

--- a/data/BGC0001470.json
+++ b/data/BGC0001470.json
@@ -20,7 +20,8 @@
         },
         {
             "comments": [
-                "Removed ketoreductase stereochemistry annotation from modules without ketoreductases"
+                "Removed ketoreductase stereochemistry annotation from modules without ketoreductases",
+                "Merged cross-CDS PKS modules"
             ],
             "contributors": [
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
@@ -315,24 +316,14 @@
                             "domains": [
                                 "Ketosynthase",
                                 "Dehydratase",
-                                "Ketoreductase"
-                            ],
-                            "genes": [
-                                "RAT98530.1"
-                            ],
-                            "kr_stereochem": "Unknown",
-                            "module_number": "1"
-                        },
-                        {
-                            "at_specificities": [
-                                "Unknown"
-                            ],
-                            "domains": [
+                                "Ketoreductase",
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
+                                "RAT98530.1",
                                 "RAT98529.1"
                             ],
+                            "kr_stereochem": "Unknown",
                             "module_number": "1",
                             "pks_mod_doms": [
                                 "Methylation"
@@ -360,24 +351,14 @@
                             ],
                             "domains": [
                                 "Ketosynthase",
-                                "Ketoreductase"
-                            ],
-                            "genes": [
-                                "RAT98529.1"
-                            ],
-                            "kr_stereochem": "Unknown",
-                            "module_number": "3"
-                        },
-                        {
-                            "at_specificities": [
-                                "Unknown"
-                            ],
-                            "domains": [
+                                "Ketoreductase",
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
+                                "RAT98529.1",
                                 "RAT98528.1"
                             ],
+                            "kr_stereochem": "Unknown",
                             "module_number": "3",
                             "pks_mod_doms": [
                                 "Methylation"
@@ -404,22 +385,12 @@
                                 "Unknown"
                             ],
                             "domains": [
-                                "Ketosynthase"
-                            ],
-                            "genes": [
-                                "RAT98528.1"
-                            ],
-                            "module_number": "5"
-                        },
-                        {
-                            "at_specificities": [
-                                "Unknown"
-                            ],
-                            "domains": [
+                                "Ketosynthase",
                                 "Dehydratase",
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
+                                "RAT98528.1",
                                 "RAT98527.1"
                             ],
                             "module_number": "5"
@@ -479,13 +450,18 @@
                             ],
                             "domains": [
                                 "Ketosynthase",
-                                "Ketoreductase"
+                                "Ketoreductase",
+                                "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
-                                "RAT98526.1"
+                                "RAT98526.1",
+                                "RAT98525.1"
                             ],
                             "kr_stereochem": "Unknown",
-                            "module_number": "10"
+                            "module_number": "10",
+                            "pks_mod_doms": [
+                                "Methylation"
+                            ]
                         },
                         {
                             "at_specificities": [
@@ -500,21 +476,6 @@
                             ],
                             "kr_stereochem": "Unknown",
                             "module_number": "9"
-                        },
-                        {
-                            "at_specificities": [
-                                "Unknown"
-                            ],
-                            "domains": [
-                                "Thiolation (ACP/PCP)"
-                            ],
-                            "genes": [
-                                "RAT98525.1"
-                            ],
-                            "module_number": "10",
-                            "pks_mod_doms": [
-                                "Methylation"
-                            ]
                         },
                         {
                             "at_specificities": [
@@ -567,40 +528,16 @@
                                 "Unknown"
                             ],
                             "domains": [
-                                "Enoylreductase",
-                                "Thiolation (ACP/PCP)"
-                            ],
-                            "genes": [
-                                "RAT98519.1"
-                            ],
-                            "module_number": "13"
-                        },
-                        {
-                            "at_specificities": [
-                                "Unknown"
-                            ],
-                            "domains": [
                                 "Ketosynthase",
                                 "Dehydratase",
                                 "Ketoreductase",
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
-                                "RAT98519.1"
-                            ],
-                            "kr_stereochem": "Unknown",
-                            "module_number": "14"
-                        },
-                        {
-                            "at_specificities": [
-                                "Unknown"
-                            ],
-                            "domains": [
-                                "Thiolation (ACP/PCP)"
-                            ],
-                            "genes": [
+                                "RAT98519.1",
                                 "RAT98518.1"
                             ],
+                            "kr_stereochem": "Unknown",
                             "module_number": "14",
                             "pks_mod_doms": [
                                 "Methylation"
@@ -641,22 +578,12 @@
                                 "Unknown"
                             ],
                             "domains": [
-                                "Ketosynthase"
-                            ],
-                            "genes": [
-                                "RAT98518.1"
-                            ],
-                            "module_number": "17"
-                        },
-                        {
-                            "at_specificities": [
-                                "Unknown"
-                            ],
-                            "domains": [
+                                "Ketosynthase",
                                 "Dehydratase",
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
+                                "RAT98518.1",
                                 "RAT98517.1"
                             ],
                             "module_number": "17"

--- a/data/BGC0001856.json
+++ b/data/BGC0001856.json
@@ -11,7 +11,8 @@
         },
         {
             "comments": [
-                "Removed ketoreductase stereochemistry annotation from modules without ketoreductases"
+                "Removed ketoreductase stereochemistry annotation from modules without ketoreductases",
+                "Corrected PKS module numbers"
             ],
             "contributors": [
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
@@ -1093,7 +1094,7 @@
                                 "QBF51757.1"
                             ],
                             "kr_stereochem": "D-OH",
-                            "module_number": "10"
+                            "module_number": "9"
                         },
                         {
                             "at_specificities": [
@@ -1110,7 +1111,7 @@
                                 "QBF51757.1"
                             ],
                             "kr_stereochem": "L-OH",
-                            "module_number": "11"
+                            "module_number": "10"
                         },
                         {
                             "at_specificities": [
@@ -1127,7 +1128,7 @@
                                 "QBF51757.1"
                             ],
                             "kr_stereochem": "D-OH",
-                            "module_number": "9"
+                            "module_number": "11"
                         },
                         {
                             "at_specificities": [
@@ -1318,7 +1319,7 @@
                             "genes": [
                                 "QBF51769.1"
                             ],
-                            "module_number": "21"
+                            "module_number": "22"
                         },
                         {
                             "at_specificities": [
@@ -1336,7 +1337,7 @@
                                 "QBF51769.1"
                             ],
                             "kr_stereochem": "D-OH",
-                            "module_number": "22"
+                            "module_number": "23"
                         }
                     ],
                     "subclass": [

--- a/data/BGC0002057.json
+++ b/data/BGC0002057.json
@@ -3,7 +3,8 @@
         {
             "comments": [
                 "Submitted",
-                "Removed ketoreductase stereochemistry annotation from modules without ketoreductases"
+                "Removed ketoreductase stereochemistry annotation from modules without ketoreductases",
+                "Removed references to invalid gene identifier"
             ],
             "contributors": [
                 "DSCNCSJNYVZZHSG74Z2O37QE",
@@ -224,7 +225,6 @@
             "synthases": [
                 {
                     "genes": [
-                        "16084-17031",
                         "pamB",
                         "pamC",
                         "pamD",
@@ -477,12 +477,7 @@
                     ],
                     "subclass": [
                         "Trans-AT type I"
-                    ],
-                    "trans_at": {
-                        "genes": [
-                            "16084-17031"
-                        ]
-                    }
+                    ]
                 }
             ]
         },

--- a/data/BGC0002057.json
+++ b/data/BGC0002057.json
@@ -4,7 +4,8 @@
             "comments": [
                 "Submitted",
                 "Removed ketoreductase stereochemistry annotation from modules without ketoreductases",
-                "Removed references to invalid gene identifier"
+                "Removed references to invalid gene identifier",
+                "Reworked NRPS/PKS modules to match reference paper"
             ],
             "contributors": [
                 "DSCNCSJNYVZZHSG74Z2O37QE",
@@ -163,26 +164,11 @@
                                     "Glycine"
                                 ]
                             },
-                            "active": false,
+                            "active": true,
                             "modification_domains": [
                                 "Methylation"
                             ],
                             "module_number": "0"
-                        }
-                    ]
-                },
-                {
-                    "gene_id": "pamB",
-                    "modules": [
-                        {
-                            "active": false,
-                            "c_dom_subtype": "Heterocyclization",
-                            "module_number": "6"
-                        },
-                        {
-                            "active": false,
-                            "c_dom_subtype": "Heterocyclization",
-                            "module_number": "7"
                         }
                     ]
                 },
@@ -197,16 +183,26 @@
                                     "Sequence-based prediction"
                                 ],
                                 "proteinogenic": [
-                                    "Cysteine"
+                                    "Serine"
                                 ]
                             },
                             "active": false,
-                            "module_number": "0"
+                            "module_number": "6"
                         },
                         {
+                            "a_substr_spec": {
+                                "aa_subcluster": [],
+                                "epimerized": false,
+                                "evidence": [
+                                    "Sequence-based prediction"
+                                ],
+                                "proteinogenic": [
+                                    "Cysteine"
+                                ]
+                            },
                             "active": true,
                             "c_dom_subtype": "LCL",
-                            "module_number": "5"
+                            "module_number": "7"
                         }
                     ]
                 }
@@ -235,7 +231,6 @@
                             "at_specificities": [
                                 "Unknown"
                             ],
-                            "comments": "",
                             "domains": [
                                 "Ketosynthase",
                                 "Dehydratase",
@@ -255,7 +250,6 @@
                             "at_specificities": [
                                 "Unknown"
                             ],
-                            "comments": "",
                             "domains": [
                                 "Ketosynthase",
                                 "Dehydratase",
@@ -266,14 +260,12 @@
                                 "pamA"
                             ],
                             "kr_stereochem": "D-OH",
-                            "module_number": "2",
-                            "pks_mod_doms": []
+                            "module_number": "2"
                         },
                         {
                             "at_specificities": [
                                 "Unknown"
                             ],
-                            "comments": "",
                             "domains": [
                                 "Ketosynthase",
                                 "Dehydratase",
@@ -303,14 +295,12 @@
                                 "pamB"
                             ],
                             "kr_stereochem": "D-OH",
-                            "module_number": "4",
-                            "pks_mod_doms": []
+                            "module_number": "4"
                         },
                         {
                             "at_specificities": [
                                 "Unknown"
                             ],
-                            "comments": "",
                             "domains": [
                                 "Ketosynthase",
                                 "Thiolation (ACP/PCP)"
@@ -318,14 +308,12 @@
                             "genes": [
                                 "pamB"
                             ],
-                            "module_number": "5",
-                            "pks_mod_doms": []
+                            "module_number": "5"
                         },
                         {
                             "at_specificities": [
                                 "Unknown"
                             ],
-                            "comments": "",
                             "domains": [
                                 "Ketosynthase",
                                 "Thiolation (ACP/PCP)"
@@ -333,7 +321,16 @@
                             "genes": [
                                 "pamC"
                             ],
-                            "module_number": "1",
+                            "module_number": "8",
+                            "non_canonical": {
+                                "evidence": [
+                                    "Sequence-based prediction"
+                                ],
+                                "iterated": false,
+                                "non_elongating": true,
+                                "skipped": false
+                            },
+
                             "pks_mod_doms": [
                                 "Oxidation"
                             ]
@@ -342,7 +339,6 @@
                             "at_specificities": [
                                 "Unknown"
                             ],
-                            "comments": "",
                             "domains": [
                                 "Ketosynthase",
                                 "Dehydratase",
@@ -351,8 +347,7 @@
                             "genes": [
                                 "pamC"
                             ],
-                            "module_number": "2",
-                            "pks_mod_doms": []
+                            "module_number": "9"
                         },
                         {
                             "at_specificities": [
@@ -360,6 +355,7 @@
                             ],
                             "comments": "aminotransferase",
                             "domains": [
+                                "Enoylreductase",
                                 "Ketosynthase",
                                 "Dehydratase",
                                 "Thiolation (ACP/PCP)"
@@ -367,16 +363,12 @@
                             "genes": [
                                 "pamC"
                             ],
-                            "module_number": "3",
-                            "pks_mod_doms": [
-                                "Methylation"
-                            ]
+                            "module_number": "10"
                         },
                         {
                             "at_specificities": [
                                 "Unknown"
                             ],
-                            "comments": "",
                             "domains": [
                                 "Ketosynthase",
                                 "Dehydratase",
@@ -385,66 +377,41 @@
                             "genes": [
                                 "pamC"
                             ],
-                            "module_number": "4",
-                            "pks_mod_doms": []
+                            "module_number": "11"
                         },
                         {
                             "at_specificities": [
                                 "Unknown"
                             ],
-                            "comments": "",
                             "domains": [
                                 "Ketosynthase",
-                                "Dehydratase",
-                                "Thiolation (ACP/PCP)",
-                                "Thioesterase"
-                            ],
-                            "genes": [
-                                "pamD"
-                            ],
-                            "module_number": "10",
-                            "pks_mod_doms": []
-                        },
-                        {
-                            "at_specificities": [
-                                "Unknown"
-                            ],
-                            "comments": "",
-                            "domains": [
-                                "Ketosynthase",
-                                "Ketoreductase"
-                            ],
-                            "genes": [
-                                "pamD"
-                            ],
-                            "kr_stereochem": "L-OH",
-                            "module_number": "6",
-                            "pks_mod_doms": []
-                        },
-                        {
-                            "at_specificities": [
-                                "Unknown"
-                            ],
-                            "comments": "",
-                            "domains": [
-                                "Ketosynthase",
-                                "Dehydratase",
-                                "Thiolation (ACP/PCP)",
+                                "Ketoreductase",
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
                                 "pamD"
                             ],
-                            "module_number": "7",
-                            "pks_mod_doms": [
-                                "Beta-branching"
-                            ]
+                            "kr_stereochem": "Unknown",
+                            "module_number": "12"
                         },
                         {
                             "at_specificities": [
                                 "Unknown"
                             ],
-                            "comments": "",
+                            "domains": [
+                                "Ketosynthase",
+                                "Dehydratase",
+                                "Thiolation (ACP/PCP)"
+                            ],
+                            "genes": [
+                                "pamD"
+                            ],
+                            "module_number": "13"
+                        },
+                        {
+                            "at_specificities": [
+                                "Unknown"
+                            ],
                             "domains": [
                                 "Ketosynthase",
                                 "Dehydratase",
@@ -455,14 +422,12 @@
                                 "pamD"
                             ],
                             "kr_stereochem": "Unknown",
-                            "module_number": "8",
-                            "pks_mod_doms": []
+                            "module_number": "14"
                         },
                         {
                             "at_specificities": [
                                 "Unknown"
                             ],
-                            "comments": "",
                             "domains": [
                                 "Ketosynthase",
                                 "Dehydratase",
@@ -471,8 +436,30 @@
                             "genes": [
                                 "pamD"
                             ],
-                            "module_number": "9",
-                            "pks_mod_doms": []
+                            "module_number": "15",
+                            "non_canonical": {
+                                "evidence": [
+                                    "Sequence-based prediction"
+                                ],
+                                "iterated": false,
+                                "non_elongating": true,
+                                "skipped": false
+                            }
+                        },
+                        {
+                            "at_specificities": [
+                                "Unknown"
+                            ],
+                            "domains": [
+                                "Ketosynthase",
+                                "Dehydratase",
+                                "Thiolation (ACP/PCP)",
+                                "Thioesterase"
+                            ],
+                            "genes": [
+                                "pamD"
+                            ],
+                            "module_number": "16"
                         }
                     ],
                     "subclass": [

--- a/pending/BGC0001853.json
+++ b/pending/BGC0001853.json
@@ -14,7 +14,8 @@
                 "Fixed NRPS module numbering",
                 "Re-added to MIBiG",
                 "Corrected NRP module activity",
-                "Removed ketoreductase stereochemistry annotation from modules without ketoreductases"
+                "Removed ketoreductase stereochemistry annotation from modules without ketoreductases",
+                "Reworked NRPS/PKS module information"
             ],
             "contributors": [
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
@@ -483,7 +484,7 @@
             "cyclic": true,
             "nrps_genes": [
                 {
-                    "gene_id": "LrgS",
+                    "gene_id": "ctg3_15",
                     "modules": [
                         {
                             "a_substr_spec": {
@@ -502,7 +503,7 @@
                     ]
                 },
                 {
-                    "gene_id": "LrgI",
+                    "gene_id": "ctg3_18",
                     "modules": [
                         {
                             "a_substr_spec": {
@@ -544,30 +545,11 @@
             "synthases": [
                 {
                     "genes": [
-                        "LrgG",
-                        "LrgA",
-                        "LrgN",
-                        "LrgJ",
-                        "LrgI",
-                        "LrgL",
-                        "LrgK"
+                        "ctg3_13",
+                        "ctg3_18",
+                        "ctg3_19"
                     ],
                     "modules": [
-                        {
-                            "at_specificities": [
-                                "Malonyl-CoA"
-                            ],
-                            "comments": "",
-                            "domains": [
-                                "Acyltransferase"
-                            ],
-                            "evidence": "Structure-based inference",
-                            "genes": [
-                                "LrgG"
-                            ],
-                            "module_number": "0",
-                            "pks_mod_doms": []
-                        },
                         {
                             "at_specificities": [
                                 "Unknown"
@@ -578,10 +560,17 @@
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
-                                "LrgI"
+                                "ctg3_18"
                             ],
                             "module_number": "3A",
-                            "pks_mod_doms": []
+                            "non_canonical": {
+                                "evidence": [
+                                    "Structure-based inference"
+                                ],
+                                "iterated": false,
+                                "non_elongating": false,
+                                "skipped": true
+                            }
                         },
                         {
                             "at_specificities": [
@@ -594,10 +583,10 @@
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
-                                "LrgI"
+                                "ctg3_18"
                             ],
                             "kr_stereochem": "Unknown",
-                            "module_number": "3B",
+                            "module_number": "3",
                             "pks_mod_doms": []
                         },
                         {
@@ -609,7 +598,7 @@
                                 "Ketosynthase"
                             ],
                             "genes": [
-                                "LrgI"
+                                "ctg3_18"
                             ],
                             "module_number": "4A",
                             "pks_mod_doms": []
@@ -625,7 +614,7 @@
                                 "Ketoreductase"
                             ],
                             "genes": [
-                                "LrgJ"
+                                "ctg3_19"
                             ],
                             "kr_stereochem": "Unknown",
                             "module_number": "4B",
@@ -641,7 +630,7 @@
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
-                                "LrgJ"
+                                "ctg3_19"
                             ],
                             "module_number": "5",
                             "pks_mod_doms": [
@@ -661,7 +650,7 @@
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
-                                "LrgJ"
+                                "ctg3_19"
                             ],
                             "kr_stereochem": "Unknown",
                             "module_number": "6",
@@ -680,7 +669,7 @@
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
-                                "LrgJ"
+                                "ctg3_19"
                             ],
                             "kr_stereochem": "Unknown",
                             "module_number": "7",
@@ -698,74 +687,22 @@
                                 "Thioesterase"
                             ],
                             "genes": [
-                                "LrgJ"
+                                "ctg3_19"
                             ],
                             "module_number": "8",
                             "pks_mod_doms": [
                                 "Beta-branching"
                             ]
-                        },
-                        {
-                            "at_specificities": [
-                                "Methylmalonyl-CoA"
-                            ],
-                            "comments": "",
-                            "domains": [
-                                "Acyltransferase"
-                            ],
-                            "evidence": "Structure-based inference",
-                            "genes": [
-                                "LrgK"
-                            ],
-                            "module_number": "0",
-                            "pks_mod_doms": []
-                        },
-                        {
-                            "at_specificities": [
-                                "Unknown"
-                            ],
-                            "comments": "",
-                            "domains": [
-                                "Thiolation (ACP/PCP)"
-                            ],
-                            "genes": [
-                                "LrgL"
-                            ],
-                            "module_number": "0",
-                            "pks_mod_doms": []
-                        },
-                        {
-                            "at_specificities": [
-                                "Unknown"
-                            ],
-                            "comments": "",
-                            "domains": [
-                                "Thiolation (ACP/PCP)"
-                            ],
-                            "genes": [
-                                "LrgA"
-                            ],
-                            "module_number": "0",
-                            "pks_mod_doms": []
-                        },
-                        {
-                            "at_specificities": [
-                                "Unknown"
-                            ],
-                            "comments": "",
-                            "domains": [
-                                "Thioesterase"
-                            ],
-                            "genes": [
-                                "LrgN"
-                            ],
-                            "module_number": "0",
-                            "pks_mod_doms": []
                         }
                     ],
                     "subclass": [
                         "Modular type I"
-                    ]
+                    ],
+                    "trans_at": {
+                        "genes": [
+                            "ctg3_13"
+                        ]
+                    }
                 }
             ]
         },

--- a/pending/BGC0002046.json
+++ b/pending/BGC0002046.json
@@ -4,7 +4,8 @@
             "comments": [
                 "Submitted",
                 "Corrected NRP module activity",
-                "Removed ketoreductase stereochemistry annotation from modules without ketoreductases"
+                "Removed ketoreductase stereochemistry annotation from modules without ketoreductases",
+                "Changed polyketide information to that described by reference paper"
             ],
             "contributors": [
                 "6CMFYLN6YIRYRVG5SRRBZ7FY",
@@ -132,6 +133,14 @@
                                 "WP_044617900.1"
                             ],
                             "module_number": "1",
+                            "non_canonical": {
+                                "evidence": [
+                                    "Sequence-based prediction"
+                                ],
+                                "iterated": false,
+                                "non_elongating": true,
+                                "skipped": false
+                            },
                             "pks_mod_doms": [
                                 "Oxidation"
                             ]
@@ -148,6 +157,14 @@
                                 "WP_044617900.1"
                             ],
                             "module_number": "2",
+                            "non_canonical": {
+                                "evidence": [
+                                    "Sequence-based prediction"
+                                ],
+                                "iterated": false,
+                                "non_elongating": true,
+                                "skipped": false
+                            },
                             "pks_mod_doms": [
                                 "Methylation"
                             ]
@@ -172,12 +189,23 @@
                                 "Unknown"
                             ],
                             "domains": [
-                                "Ketosynthase"
+                                "Ketosynthase",
+                                "Dehydratase",
+                                "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
-                                "WP_044617900.1"
+                                "WP_044617900.1",
+                                "WP_052830344.1"
                             ],
-                            "module_number": "4"
+                            "module_number": "4",
+                            "non_canonical": {
+                                "evidence": [
+                                    "Sequence-based prediction"
+                                ],
+                                "iterated": true,
+                                "non_elongating": false,
+                                "skipped": false
+                            }
                         },
                         {
                             "at_specificities": [
@@ -193,22 +221,7 @@
                                 "WP_052830344.1"
                             ],
                             "kr_stereochem": "D-OH",
-                            "module_number": "6",
-                            "pks_mod_doms": [
-                                "Methylation"
-                            ]
-                        },
-                        {
-                            "at_specificities": [
-                                "Unknown"
-                            ],
-                            "domains": [
-                                "Ketosynthase"
-                            ],
-                            "genes": [
-                                "WP_052830344.1"
-                            ],
-                            "module_number": "7"
+                            "module_number": "6"
                         },
                         {
                             "at_specificities": [
@@ -216,43 +229,11 @@
                             ],
                             "domains": [
                                 "Ketosynthase",
-                                "Dehydratase",
                                 "Ketoreductase",
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
-                                "WP_044617899.1"
-                            ],
-                            "kr_stereochem": "D-OH",
-                            "module_number": "10"
-                        },
-                        {
-                            "at_specificities": [
-                                "Unknown"
-                            ],
-                            "domains": [
-                                "Ketosynthase",
-                                "Dehydratase",
-                                "Ketoreductase"
-                            ],
-                            "genes": [
-                                "WP_044617899.1"
-                            ],
-                            "kr_stereochem": "Unknown",
-                            "module_number": "11",
-                            "pks_mod_doms": [
-                                "Methylation"
-                            ]
-                        },
-                        {
-                            "at_specificities": [
-                                "Unknown"
-                            ],
-                            "domains": [
-                                "Ketoreductase",
-                                "Thiolation (ACP/PCP)"
-                            ],
-                            "genes": [
+                                "WP_052830344.1",
                                 "WP_044617899.1"
                             ],
                             "kr_stereochem": "L-OH",
@@ -269,7 +250,7 @@
                             "genes": [
                                 "WP_044617899.1"
                             ],
-                            "module_number": "9",
+                            "module_number": "8",
                             "pks_mod_doms": [
                                 "Methylation",
                                 "  Oxidation"
@@ -280,12 +261,36 @@
                                 "Unknown"
                             ],
                             "domains": [
+                                "Ketosynthase",
+                                "Dehydratase",
+                                "Ketoreductase",
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
+                                "WP_044617899.1"
+                            ],
+                            "kr_stereochem": "D-OH",
+                            "module_number": "9"
+                        },
+                        {
+                            "at_specificities": [
+                                "Unknown"
+                            ],
+                            "domains": [
+                                "Ketosynthase",
+                                "Dehydratase",
+                                "Ketoreductase",
+                                "Thiolation (ACP/PCP)"
+                            ],
+                            "genes": [
+                                "WP_044617899.1",
                                 "WP_052830343.1"
                             ],
-                            "module_number": "11"
+                            "kr_stereochem": "Unknown",
+                            "module_number": "10",
+                            "pks_mod_doms": [
+                                "Methylation"
+                            ]
                         },
                         {
                             "at_specificities": [
@@ -301,7 +306,7 @@
                                 "WP_052830343.1"
                             ],
                             "kr_stereochem": "D-OH",
-                            "module_number": "12"
+                            "module_number": "11"
                         },
                         {
                             "at_specificities": [
@@ -314,7 +319,7 @@
                             "genes": [
                                 "WP_052830343.1"
                             ],
-                            "module_number": "13"
+                            "module_number": "12"
                         },
                         {
                             "at_specificities": [
@@ -329,7 +334,7 @@
                                 "WP_052830343.1"
                             ],
                             "kr_stereochem": "Unknown",
-                            "module_number": "14"
+                            "module_number": "13"
                         },
                         {
                             "at_specificities": [
@@ -344,21 +349,12 @@
                             "genes": [
                                 "WP_052830342.1"
                             ],
-                            "module_number": "15"
+                            "module_number": "14"
                         }
                     ],
                     "subclass": [
                         "Trans-AT type I"
-                    ],
-                    "trans_at": {
-                        "genes": [
-                            "wp_052830342.1",
-                            "wp_052830343.1",
-                            "wp_044617899.1",
-                            "wp_052830344.1",
-                            "wp_044617900.1"
-                        ]
-                    }
+                    ]
                 }
             ]
         },

--- a/pending/BGC0002050.json
+++ b/pending/BGC0002050.json
@@ -6,7 +6,8 @@
                 "Corrected NRP module activity",
                 "Removed erroneous gene name",
                 "Removed gene annotations with no information",
-                "Removed ketoreductase stereochemistry annotation from modules without ketoreductases"
+                "Removed ketoreductase stereochemistry annotation from modules without ketoreductases",
+                "Merged cross-CDS PKS modules"
             ],
             "contributors": [
                 "Z7AIIJAM3U3HR6IYDPQOINM4",
@@ -287,20 +288,6 @@
                                 "Unknown"
                             ],
                             "domains": [
-                                "Dehydratase",
-                                "Thiolation (ACP/PCP)",
-                                "Dehydratase"
-                            ],
-                            "genes": [
-                                "QIE07367.1"
-                            ],
-                            "module_number": "13"
-                        },
-                        {
-                            "at_specificities": [
-                                "Unknown"
-                            ],
-                            "domains": [
                                 "Ketosynthase",
                                 "Thiolation (ACP/PCP)"
                             ],
@@ -344,20 +331,6 @@
                                 "Unknown"
                             ],
                             "domains": [
-                                "Dehydratase",
-                                "Thiolation (ACP/PCP)",
-                                "Dehydratase"
-                            ],
-                            "genes": [
-                                "QIE07366.1"
-                            ],
-                            "module_number": "11"
-                        },
-                        {
-                            "at_specificities": [
-                                "Unknown"
-                            ],
-                            "domains": [
                                 "Ketosynthase",
                                 "Ketoreductase",
                                 "Thiolation (ACP/PCP)"
@@ -373,10 +346,14 @@
                                 "Unknown"
                             ],
                             "domains": [
-                                "Ketosynthase"
+                                "Ketosynthase",
+                                "Dehydratase",
+                                "Thiolation (ACP/PCP)",
+                                "Dehydratase"
                             ],
                             "genes": [
-                                "QIE07366.1"
+                                "QIE07366.1",
+                                "QIE07367.1"
                             ],
                             "module_number": "13"
                         },
@@ -400,10 +377,14 @@
                                 "Unknown"
                             ],
                             "domains": [
-                                "Ketosynthase"
+                                "Ketosynthase",
+                                "Dehydratase",
+                                "Thiolation (ACP/PCP)",
+                                "Dehydratase"
                             ],
                             "genes": [
-                                "QIE07365.1"
+                                "QIE07365.1",
+                                "QIE07366.1"
                             ],
                             "module_number": "11"
                         },

--- a/pending/BGC0002059.json
+++ b/pending/BGC0002059.json
@@ -4,7 +4,8 @@
             "comments": [
                 "Submitted",
                 "Corrected NRP module activity",
-                "Removed ketoreductase stereochemistry annotation from modules without ketoreductases"
+                "Removed ketoreductase stereochemistry annotation from modules without ketoreductases",
+                "Merged cross-CDS PKS modules"
             ],
             "contributors": [
                 "RLTUJMQB5UUY7AZHW5PDUHV4",
@@ -237,11 +238,16 @@
                                 "Unknown"
                             ],
                             "domains": [
-                                "Ketosynthase"
+                                "Ketosynthase",
+                                "Dehydratase",
+                                "Ketoreductase",
+                                "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
-                                "sxcE"
+                                "sxcE",
+                                "sxcF"
                             ],
+                            "kr_stereochem": "Unknown",
                             "module_number": "8"
                         },
                         {
@@ -266,30 +272,18 @@
                                 "Unknown"
                             ],
                             "domains": [
-                                "Ketosynthase"
+                                "Ketosynthase",
+                                "Thiolation (ACP/PCP)",
+                                "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
-                                "sxcF"
+                                "sxcF",
+                                "sxcG"
                             ],
                             "module_number": "11",
                             "pks_mod_doms": [
                                 "Oxidation"
                             ]
-                        },
-                        {
-                            "at_specificities": [
-                                "Unknown"
-                            ],
-                            "domains": [
-                                "Dehydratase",
-                                "Ketoreductase",
-                                "Thiolation (ACP/PCP)"
-                            ],
-                            "genes": [
-                                "sxcF"
-                            ],
-                            "kr_stereochem": "Unknown",
-                            "module_number": "8"
                         },
                         {
                             "at_specificities": [
@@ -305,19 +299,6 @@
                             ],
                             "kr_stereochem": "Unknown",
                             "module_number": "9"
-                        },
-                        {
-                            "at_specificities": [
-                                "Unknown"
-                            ],
-                            "domains": [
-                                "Thiolation (ACP/PCP)",
-                                "Thiolation (ACP/PCP)"
-                            ],
-                            "genes": [
-                                "sxcG"
-                            ],
-                            "module_number": "11"
                         },
                         {
                             "at_specificities": [

--- a/pending/BGC0002060.json
+++ b/pending/BGC0002060.json
@@ -3,7 +3,8 @@
         {
             "comments": [
                 "Submitted",
-                "Removed ketoreductase stereochemistry annotation from modules without ketoreductases"
+                "Removed ketoreductase stereochemistry annotation from modules without ketoreductases",
+                "Merged cross-CDS PKS modules"
             ],
             "contributors": [
                 "NXU2DC3KF53Q3BQ3CSVJITHE",
@@ -102,22 +103,12 @@
                                 "Unknown"
                             ],
                             "domains": [
-                                "Ketosynthase"
-                            ],
-                            "genes": [
-                                "AAY39344"
-                            ],
-                            "module_number": "3"
-                        },
-                        {
-                            "at_specificities": [
-                                "Unknown"
-                            ],
-                            "domains": [
+                                "Ketosynthase",
                                 "Ketoreductase",
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
+                                "AAY39344",
                                 "AAY39343"
                             ],
                             "kr_stereochem": "Unknown",
@@ -145,22 +136,12 @@
                             ],
                             "domains": [
                                 "Ketosynthase",
-                                "Dehydratase"
-                            ],
-                            "genes": [
-                                "AAY39343"
-                            ],
-                            "module_number": "5"
-                        },
-                        {
-                            "at_specificities": [
-                                "Unknown"
-                            ],
-                            "domains": [
+                                "Dehydratase",
                                 "Ketoreductase",
                                 "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
+                                "AAY39343",
                                 "AAY39342"
                             ],
                             "kr_stereochem": "Unknown",

--- a/pending/BGC0002083.json
+++ b/pending/BGC0002083.json
@@ -3,7 +3,8 @@
         {
             "comments": [
                 "Submitted",
-                "Removed ketoreductase stereochemistry annotation from modules without ketoreductases"
+                "Removed ketoreductase stereochemistry annotation from modules without ketoreductases",
+                "Merged cross-CDS PKS modules"
             ],
             "contributors": [
                 "Z7AIIJAM3U3HR6IYDPQOINM4",
@@ -122,11 +123,15 @@
                                 "Unknown"
                             ],
                             "domains": [
-                                "Ketosynthase"
+                                "Ketosynthase",
+                                "Ketoreductase",
+                                "Thiolation (ACP/PCP)"
                             ],
                             "genes": [
-                                "WP_160294283.1"
+                                "WP_160294283.1",
+                                "WP_160294282.1"
                             ],
+                            "kr_stereochem": "Unknown",
                             "module_number": "3"
                         },
                         {
@@ -141,20 +146,6 @@
                                 "WP_160294282.1"
                             ],
                             "module_number": "10"
-                        },
-                        {
-                            "at_specificities": [
-                                "Unknown"
-                            ],
-                            "domains": [
-                                "Ketoreductase",
-                                "Thiolation (ACP/PCP)"
-                            ],
-                            "genes": [
-                                "WP_160294282.1"
-                            ],
-                            "kr_stereochem": "Unknown",
-                            "module_number": "3"
                         },
                         {
                             "at_specificities": [

--- a/scripts/check_valid.py
+++ b/scripts/check_valid.py
@@ -44,6 +44,23 @@ def check_kr_stereochem(data: Dict[str, Any], prefix: str) -> bool:
     return True
 
 
+def check_pks_module_duplication(data: Dict[str, Any], prefix: str) -> bool:
+    for synthase in data["cluster"].get("polyketide", {}).get("synthases", []):
+        module_numbers = set()
+        duplicates = set()
+        for module in synthase.get("modules", []):
+            num = module.get("module_number")
+            if num is None:
+                continue
+            if num in module_numbers:
+                duplicates.add(num)
+            module_numbers.add(num)
+        if duplicates:
+            print(f"{prefix}contains duplicate PKS module numbers: {sorted(duplicates)}")
+            return False
+    return True
+
+
 def check_all() -> bool:
     valid = True
     for dir_name in ["data", "pending"]:
@@ -80,6 +97,7 @@ def check_single(file: str, prefix: str = "") -> bool:
         for func in [
             check_gene_duplication,
             check_kr_stereochem,
+            check_pks_module_duplication,
         ]:
             valid = func(data, prefix) and valid
     except KeyError as err:


### PR DESCRIPTION
Most (or all) PKS modules that involved multiple genes were duplicating the module number and not listing both genes as the schema already allows for. This PR merges all those cross-gene modules and removes or corrects any other module number duplications in polyketide information.

A number of incidental fixes were included where the polyketide annotations used gene names inconsistently or completely incorrectly.