### PR TITLE
Add metadata and cross-references for several BGC products

### DIFF
--- a/data/BGC0000231.json
+++ b/data/BGC0000231.json
@@ -25,7 +25,22 @@
         ],
         "compounds": [
             {
-                "compound": "griseusin"
+                "chem_struct": "C[C@@H]1C[C@H]([C@H]([C@@]2(O1)C3=C([C@@H]4[C@H](O2)CC(=O)O4)C(=O)C5=C(C3=O)C(=CC=C5)O)O)OC(=O)C",
+                "compound": "griseusin A",
+                "database_id": [
+                    "pubchem:16102131"
+                ],
+                "mol_mass": "444.10564683",
+                "molecular_formula": "C22H20O10"
+            },
+            {
+                "chem_struct": "C[C@@H]1C[C@H]([C@@H]([C@@]2(O1)C3=C(C[C@H](O2)CC(=O)O)C(=O)C4=C(C3=O)C(=CC=C4)O)O)OC(=O)C",
+                "compound": "griseusin B",
+                "database_id": [
+                    "pubchem:10321333"
+                ],
+                "mol_mass": "446.12129689",
+                "molecular_formula": "C22H22O10"
             }
         ],
         "loci": {

--- a/data/BGC0000231.json
+++ b/data/BGC0000231.json
@@ -30,7 +30,7 @@
                 "database_id": [
                     "pubchem:16102131"
                 ],
-                "mol_mass": "444.10564683",
+                "mol_mass": 444.10564683,
                 "molecular_formula": "C22H20O10"
             },
             {
@@ -39,7 +39,7 @@
                 "database_id": [
                     "pubchem:10321333"
                 ],
-                "mol_mass": "446.12129689",
+                "mol_mass": 446.12129689,
                 "molecular_formula": "C22H22O10"
             }
         ],

--- a/data/BGC0000243.json
+++ b/data/BGC0000243.json
@@ -25,7 +25,49 @@
         ],
         "compounds": [
             {
-                "compound": "macrotetrolide"
+                "chem_struct": "C[C@@H]1C[C@H]2CC[C@H](O2)[C@@H](C(=O)O[C@H](C[C@@H]3CC[C@@H](O3)[C@H](C(=O)O[C@@H](C[C@H]4CC[C@H](O4)[C@@H](C(=O)O[C@H](C[C@@H]5CC[C@@H](O5)[C@H](C(=O)O1)C)C)C)C)C)C)C",
+                "compound": "nonactin",
+                "database_id": [
+                    "pubchem:72519"
+                ],
+                "mol_mass": "736.43977747",
+                "molecular_formula": "C40H64O12"
+            },
+            {
+                "chem_struct": "CC[C@@H]1C[C@H]2CC[C@H](O2)[C@@H](C(=O)O[C@H](C[C@@H]3CC[C@@H](O3)[C@H](C(=O)O[C@@H](C[C@H]4CC[C@H](O4)[C@@H](C(=O)O[C@H](C[C@@H]5CC[C@@H](O5)[C@H](C(=O)O1)C)C)C)C)C)C)C",
+                "compound": "monactin",
+                "database_id": [
+                    "pubchem:15560592"
+                ],
+                "mol_mass": "750.45542754",
+                "molecular_formula": "C41H66O12"
+            },
+            {
+                "chem_struct": "CCC1CC2CCC(O2)C(C(=O)OC(CC3CCC(O3)C(C(=O)OC(CC4CCC(O4)C(C(=O)OC(CC5CCC(O5)C(C(=O)O1)C)C)C)CC)C)C)C",
+                "compound": "dinactin",
+                "database_id": [
+                    "pubchem:248000"
+                ],
+                "mol_mass": "764.47107760",
+                "molecular_formula": "C42H68O12"
+            },
+            {
+                "chem_struct": "CC[C@@H]1C[C@H]2CC[C@H](O2)[C@@H](C(=O)O[C@H](C[C@@H]3CC[C@@H](O3)[C@H](C(=O)O[C@@H](C[C@H]4CC[C@H](O4)[C@@H](C(=O)O[C@H](C[C@@H]5CC[C@@H](O5)[C@H](C(=O)O1)C)CC)C)CC)C)C)C",
+                "compound": "trinactin",
+                "database_id": [
+                    "pubchem:169021"
+                ],
+                "mol_mass": "778.48672766",
+                "molecular_formula": "C43H70O12"
+            },
+            {
+                "chem_struct": "CC[C@H]1C[C@@H]2CC[C@@H](O2)[C@H](C(=O)O[C@@H](C[C@H]3CC[C@H](O3)[C@@H](C(=O)O[C@H](C[C@@H]4CC[C@@H](O4)[C@H](C(=O)O[C@@H](C[C@H]5CC[C@H](O5)[C@@H](C(=O)O1)C)CC)C)CC)C)CC)C",
+                "compound": "tetranactin",
+                "database_id": [
+                    "pubchem:441165"
+                ],
+                "mol_mass": "792.50237773",
+                "molecular_formula": "C44H72O12"
             }
         ],
         "loci": {

--- a/data/BGC0000243.json
+++ b/data/BGC0000243.json
@@ -30,7 +30,7 @@
                 "database_id": [
                     "pubchem:72519"
                 ],
-                "mol_mass": "736.43977747",
+                "mol_mass": 736.43977747,
                 "molecular_formula": "C40H64O12"
             },
             {
@@ -39,7 +39,7 @@
                 "database_id": [
                     "pubchem:15560592"
                 ],
-                "mol_mass": "750.45542754",
+                "mol_mass": 750.45542754,
                 "molecular_formula": "C41H66O12"
             },
             {
@@ -48,7 +48,7 @@
                 "database_id": [
                     "pubchem:248000"
                 ],
-                "mol_mass": "764.47107760",
+                "mol_mass": 764.47107760,
                 "molecular_formula": "C42H68O12"
             },
             {
@@ -57,7 +57,7 @@
                 "database_id": [
                     "pubchem:169021"
                 ],
-                "mol_mass": "778.48672766",
+                "mol_mass": 778.48672766,
                 "molecular_formula": "C43H70O12"
             },
             {
@@ -66,7 +66,7 @@
                 "database_id": [
                     "pubchem:441165"
                 ],
-                "mol_mass": "792.50237773",
+                "mol_mass": 792.50237773,
                 "molecular_formula": "C44H72O12"
             }
         ],

--- a/data/BGC0000244.json
+++ b/data/BGC0000244.json
@@ -25,7 +25,49 @@
         ],
         "compounds": [
             {
-                "compound": "macrotetrolide"
+                "chem_struct": "C[C@@H]1C[C@H]2CC[C@H](O2)[C@@H](C(=O)O[C@H](C[C@@H]3CC[C@@H](O3)[C@H](C(=O)O[C@@H](C[C@H]4CC[C@H](O4)[C@@H](C(=O)O[C@H](C[C@@H]5CC[C@@H](O5)[C@H](C(=O)O1)C)C)C)C)C)C)C",
+                "compound": "nonactin",
+                "database_id": [
+                    "pubchem:72519"
+                ],
+                "mol_mass": "736.43977747",
+                "molecular_formula": "C40H64O12"
+            },
+            {
+                "chem_struct": "CC[C@@H]1C[C@H]2CC[C@H](O2)[C@@H](C(=O)O[C@H](C[C@@H]3CC[C@@H](O3)[C@H](C(=O)O[C@@H](C[C@H]4CC[C@H](O4)[C@@H](C(=O)O[C@H](C[C@@H]5CC[C@@H](O5)[C@H](C(=O)O1)C)C)C)C)C)C)C",
+                "compound": "monactin",
+                "database_id": [
+                    "pubchem:15560592"
+                ],
+                "mol_mass": "750.45542754",
+                "molecular_formula": "C41H66O12"
+            },
+            {
+                "chem_struct": "CCC1CC2CCC(O2)C(C(=O)OC(CC3CCC(O3)C(C(=O)OC(CC4CCC(O4)C(C(=O)OC(CC5CCC(O5)C(C(=O)O1)C)C)C)CC)C)C)C",
+                "compound": "dinactin",
+                "database_id": [
+                    "pubchem:248000"
+                ],
+                "mol_mass": "764.47107760",
+                "molecular_formula": "C42H68O12"
+            },
+            {
+                "chem_struct": "CC[C@@H]1C[C@H]2CC[C@H](O2)[C@@H](C(=O)O[C@H](C[C@@H]3CC[C@@H](O3)[C@H](C(=O)O[C@@H](C[C@H]4CC[C@H](O4)[C@@H](C(=O)O[C@H](C[C@@H]5CC[C@@H](O5)[C@H](C(=O)O1)C)CC)C)CC)C)C)C",
+                "compound": "trinactin",
+                "database_id": [
+                    "pubchem:169021"
+                ],
+                "mol_mass": "778.48672766",
+                "molecular_formula": "C43H70O12"
+            },
+            {
+                "chem_struct": "CC[C@H]1C[C@@H]2CC[C@@H](O2)[C@H](C(=O)O[C@@H](C[C@H]3CC[C@H](O3)[C@@H](C(=O)O[C@H](C[C@@H]4CC[C@@H](O4)[C@H](C(=O)O[C@@H](C[C@H]5CC[C@H](O5)[C@@H](C(=O)O1)C)CC)C)CC)C)CC)C",
+                "compound": "tetranactin",
+                "database_id": [
+                    "pubchem:441165"
+                ],
+                "mol_mass": "792.50237773",
+                "molecular_formula": "C44H72O12"
             }
         ],
         "loci": {

--- a/data/BGC0000244.json
+++ b/data/BGC0000244.json
@@ -30,7 +30,7 @@
                 "database_id": [
                     "pubchem:72519"
                 ],
-                "mol_mass": "736.43977747",
+                "mol_mass": 736.43977747,
                 "molecular_formula": "C40H64O12"
             },
             {
@@ -39,7 +39,7 @@
                 "database_id": [
                     "pubchem:15560592"
                 ],
-                "mol_mass": "750.45542754",
+                "mol_mass": 750.45542754,
                 "molecular_formula": "C41H66O12"
             },
             {
@@ -48,7 +48,7 @@
                 "database_id": [
                     "pubchem:248000"
                 ],
-                "mol_mass": "764.47107760",
+                "mol_mass": 764.47107760,
                 "molecular_formula": "C42H68O12"
             },
             {
@@ -57,7 +57,7 @@
                 "database_id": [
                     "pubchem:169021"
                 ],
-                "mol_mass": "778.48672766",
+                "mol_mass": 778.48672766,
                 "molecular_formula": "C43H70O12"
             },
             {
@@ -66,7 +66,7 @@
                 "database_id": [
                     "pubchem:441165"
                 ],
-                "mol_mass": "792.50237773",
+                "mol_mass": 792.50237773,
                 "molecular_formula": "C44H72O12"
             }
         ],

--- a/data/BGC0000248.json
+++ b/data/BGC0000248.json
@@ -30,7 +30,7 @@
                 "database_id": [
                     "pubchem:102267544"
                 ],
-                "mol_mass": "666.15847025",
+                "mol_mass": 666.15847025,
                 "molecular_formula": "C33H30O15"
             }
         ],

--- a/data/BGC0000248.json
+++ b/data/BGC0000248.json
@@ -25,7 +25,13 @@
         ],
         "compounds": [
             {
-                "compound": "naphtocyclinone"
+                "chem_struct": "C[C@H]1C2=C(C3=C(C=C2C[C@@H](O1)CC(=O)OC)[C@]4(C[C@@H](C3=O)C5=C4C(=C6C(=C5O)C(=O)C(=O)C(=C6O)C[C@H](CC(=O)O)O)O)OC(=O)C)O",
+                "compound": "α-naphthocyclinone",
+                "database_id": [
+                    "pubchem:102267544"
+                ],
+                "mol_mass": "666.15847025",
+                "molecular_formula": "C33H30O15"
             }
         ],
         "loci": {

--- a/data/BGC0000308.json
+++ b/data/BGC0000308.json
@@ -25,7 +25,31 @@
         ],
         "compounds": [
             {
-                "compound": "aureusimine"
+                "chem_struct": "CC(C)C1=NC=C(NC1=O)CC2=CC=C(C=C2)O",
+                "compound": "aureusimine A",
+                "database_id": [
+                    "pubchem:49838500"
+                ],
+                "mol_mass": "244.121177757",
+                "molecular_formula": "C14H16N2O2"
+            },
+            {
+                "chem_struct": "CC(C)C1=NC=C(NC1=O)CC2=CC=CC=C2",
+                "compound": "aureusimine B",
+                "database_id": [
+                    "pubchem:10376483"
+                ],
+                "mol_mass": "228.126263138",
+                "molecular_formula": "C14H16N2O"
+            },
+            {
+                "chem_struct": "CC(C)CC1=CN=C(C(=O)N1)C(C)C",
+                "compound": "aureusimine C",
+                "database_id": [
+                    "pubchem:121434429"
+                ],
+                "mol_mass": "194.141913202",
+                "molecular_formula": "C11H18N2O"
             }
         ],
         "loci": {

--- a/data/BGC0000308.json
+++ b/data/BGC0000308.json
@@ -30,7 +30,7 @@
                 "database_id": [
                     "pubchem:49838500"
                 ],
-                "mol_mass": "244.121177757",
+                "mol_mass": 244.121177757,
                 "molecular_formula": "C14H16N2O2"
             },
             {
@@ -39,7 +39,7 @@
                 "database_id": [
                     "pubchem:10376483"
                 ],
-                "mol_mass": "228.126263138",
+                "mol_mass": 228.126263138,
                 "molecular_formula": "C14H16N2O"
             },
             {
@@ -48,7 +48,7 @@
                 "database_id": [
                     "pubchem:121434429"
                 ],
-                "mol_mass": "194.141913202",
+                "mol_mass": 194.141913202,
                 "molecular_formula": "C11H18N2O"
             }
         ],

--- a/data/BGC0000402.json
+++ b/data/BGC0000402.json
@@ -30,7 +30,7 @@
                 "database_id": [
                     "pubchem:139588779"
                 ],
-                "mol_mass": "1111.60259431",
+                "mol_mass": 1111.60259431,
                 "molecular_formula": "C52H81N13O14"
             },
             {
@@ -39,7 +39,7 @@
                 "database_id": [
                     "pubchem:139588780"
                 ],
-                "mol_mass": "1112.58660989",
+                "mol_mass": 1112.58660989,
                 "molecular_formula": "C52H80N12O15"
             },
             {
@@ -48,7 +48,7 @@
                 "database_id": [
                     "pubchem:139588781"
                 ],
-                "mol_mass": "1083.57129418",
+                "mol_mass": 1083.57129418,
                 "molecular_formula": "C50H77N13O14"
             }
         ],

--- a/data/BGC0000402.json
+++ b/data/BGC0000402.json
@@ -25,7 +25,31 @@
         ],
         "compounds": [
             {
-                "compound": "paenilarvins"
+                "chem_struct": "CCC(C)CCCCCCCCCC[C@H]1CC(=O)N[C@H](C(=O)N[C@@H](C(=O)N[C@@H](C(=O)N[C@H](C(=O)N2CCC[C@@H]2C(=O)N[C@@H](C(=O)N[C@H](C(=O)N1)CC(=O)N)CC(=O)N)CCC(=O)N)CC(=O)N)CC3=CC=C(C=C3)O)CC(=O)N",
+                "compound": "paenilarvin A",
+                "database_id": [
+                    "pubchem:139588779"
+                ],
+                "mol_mass": "1111.60259431",
+                "molecular_formula": "C52H81N13O14"
+            },
+            {
+                "chem_struct": "CCC(C)CCCCCCCCCC[C@H]1CC(=O)N[C@H](C(=O)N[C@@H](C(=O)N[C@@H](C(=O)N[C@H](C(=O)N2CCC[C@@H]2C(=O)N[C@@H](C(=O)N[C@H](C(=O)N1)CC(=O)N)CC(=O)N)CCC(=O)N)CC(=O)N)CC3=CC=C(C=C3)O)CC(=O)O",
+                "compound": "paenilarvin B",
+                "database_id": [
+                    "pubchem:139588780"
+                ],
+                "mol_mass": "1112.58660989",
+                "molecular_formula": "C52H80N12O15"
+            },
+            {
+                "chem_struct": "CC(C)CCCCCCCCC[C@H]1CC(=O)N[C@H](C(=O)N[C@@H](C(=O)N[C@@H](C(=O)N[C@H](C(=O)N2CCC[C@@H]2C(=O)N[C@@H](C(=O)N[C@H](C(=O)N1)CC(=O)N)CC(=O)N)CCC(=O)N)CC(=O)N)CC3=CC=C(C=C3)O)CC(=O)N",
+                "compound": "paenilarvin C",
+                "database_id": [
+                    "pubchem:139588781"
+                ],
+                "mol_mass": "1083.57129418",
+                "molecular_formula": "C50H77N13O14"
             }
         ],
         "loci": {

--- a/data/BGC0000662.json
+++ b/data/BGC0000662.json
@@ -30,7 +30,7 @@
                 "database_id": [
                     "pubchem:71464599"
                 ],
-                "mol_mass": "401.06815638",
+                "mol_mass": 401.06815638,
                 "molecular_formula": "C18H15N3O6S"
             }
         ],
@@ -48,7 +48,7 @@
             "pubmed:18375553",
             "pubmed:18364359",
             "pubmed:18310036",
-            "pubmed:17617696",
+            "pubmed:17617696"
         ]
     }
 }

--- a/data/BGC0000662.json
+++ b/data/BGC0000662.json
@@ -25,7 +25,13 @@
         ],
         "compounds": [
             {
-                "compound": "grixazone"
+                "chem_struct": "CC(=O)N[C@@H](CSC1=C(C(=O)C=C2C1=NC3=C(O2)C=CC(=C3)C=O)N)C(=O)O",
+                "compound": "grixazone A",
+                "database_id": [
+                    "pubchem:71464599"
+                ],
+                "mol_mass": "401.06815638",
+                "molecular_formula": "C18H15N3O6S"
             }
         ],
         "loci": {
@@ -41,7 +47,8 @@
         "publications": [
             "pubmed:18375553",
             "pubmed:18364359",
-            "pubmed:18310036"
+            "pubmed:18310036",
+            "pubmed:17617696",
         ]
     }
 }

--- a/data/BGC0001167.json
+++ b/data/BGC0001167.json
@@ -36,7 +36,40 @@
         ],
         "compounds": [
             {
-                "compound": "piricyclamide"
+                "chem_struct": "CC(C)[C@H]1C(=O)N[C@H](C(=O)N[C@H](C(=O)N[C@H](C(=O)N[C@H](C(=O)N2CCC[C@H]2C(=O)N[C@H](C(=O)N[C@H](C(=O)NCC(=O)N1)CO)CCSC)CC(=O)N)CC3=CC=C(C=C3)O)CC4=CC=C(C=C4)OC/C=C(/C)\\CCC=C(C)C)CC(=O)O",
+                "compound": "piricyclamide 7005E1",
+                "database_id": [
+                    "pubchem:146684880"
+                ],
+                "mol_mass": "1162.53688299",
+                "molecular_formula": "C56H78N10O15S"
+            },
+            {
+                "chem_struct": "CC[C@H](C)[C@H]1C(=O)N[C@H](C(=O)N[C@H](C(=O)N[C@H](C(=O)N[C@H](C(=O)NCC(=O)N[C@H](C(=O)N[C@H](C(=O)N2CCC[C@H]2C(=O)N[C@H](C(=O)N[C@H](C(=O)N[C@H](C(=O)N3CCC[C@H]3C(=O)N[C@H](C(=O)N1)CC4=CNC5=CC=CC=C54)C)CC(=O)N)CCCCN)CCCN=C(N)N)[C@@H](C)O)CC(=O)O)C)CC(C)C)CC(C)C",
+                "compound": "piricyclamide 7005E2",
+                "database_id": [
+                    "pubchem:146684882"
+                ],
+                "mol_mass": "1532.84634680",
+                "molecular_formula": "C71H112N20O18"
+            },
+            {
+                "chem_struct": "C[C@H]([C@H]1C(=O)NCC(=O)N[C@H](C(=O)N[C@H](C(=O)N[C@H](C(=O)NCC(=O)N2CCC[C@H]2C(=O)N[C@H](C(=O)N[C@@H](C(=O)N[C@H](C(=O)N[C@H](C(=O)N[C@H](C(=O)N1)CCC(=O)N)CCSC)CC3=CC=CC=C3)CCC(=O)O)CC(=O)N)CO)CC4=CC=C(C=C4)O)CO)O",
+                "compound": "piricyclamide 7005E3",
+                "database_id": [
+                    "pubchem:146684883"
+                ],
+                "mol_mass": "1298.52375211",
+                "molecular_formula": "C56H78N14O20S"
+            },
+            {
+                "chem_struct": "C[C@H]1C(=O)N[C@H](C(=O)N[C@@H](C(=O)N[C@H](C(=O)N[C@@H]2CSSC[C@@H](C(=O)N[C@H](C(=O)N[C@H](C(=O)N1)CC(C)C)CC(=O)O)NC(=O)[C@@H](NC(=O)[C@H](NC(=O)[C@@H]3CCCN3C(=O)[C@@H](NC2=O)CC4=CC=C(C=C4)O)[C@@H](C)O)CC5=CC=CC=C5)CCC(=O)N)CCCCN)[C@@H](C)O",
+                "compound": "piricyclamide 7005E4",
+                "database_id": [
+                    "pubchem:146684884"
+                ],
+                "mol_mass": "1368.58424436",
+                "molecular_formula": "C61H88N14O18S2"
             }
         ],
         "genes": {

--- a/data/BGC0001167.json
+++ b/data/BGC0001167.json
@@ -41,7 +41,7 @@
                 "database_id": [
                     "pubchem:146684880"
                 ],
-                "mol_mass": "1162.53688299",
+                "mol_mass": 1162.53688299,
                 "molecular_formula": "C56H78N10O15S"
             },
             {
@@ -50,7 +50,7 @@
                 "database_id": [
                     "pubchem:146684882"
                 ],
-                "mol_mass": "1532.84634680",
+                "mol_mass": 1532.84634680,
                 "molecular_formula": "C71H112N20O18"
             },
             {
@@ -59,7 +59,7 @@
                 "database_id": [
                     "pubchem:146684883"
                 ],
-                "mol_mass": "1298.52375211",
+                "mol_mass": 1298.52375211,
                 "molecular_formula": "C56H78N14O20S"
             },
             {
@@ -68,7 +68,7 @@
                 "database_id": [
                     "pubchem:146684884"
                 ],
-                "mol_mass": "1368.58424436",
+                "mol_mass": 1368.58424436,
                 "molecular_formula": "C61H88N14O18S2"
             }
         ],

--- a/data/BGC0001216.json
+++ b/data/BGC0001216.json
@@ -31,7 +31,7 @@
                 "database_id": [
                     "pubchem:42626285"
                 ],
-                "mol_mass": "554.22643067",
+                "mol_mass": 554.22643067,
                 "molecular_formula": "C29H34N2O9"
             }
         ],

--- a/data/BGC0001216.json
+++ b/data/BGC0001216.json
@@ -26,7 +26,13 @@
         ],
         "compounds": [
             {
-                "compound": "splenocin"
+                "chem_struct": "CCC(C)C(=O)O[C@H]1[C@@H](OC(=O)[C@H]([C@H](OC(=O)[C@@H]1CC2=CC=CC=C2)C)NC(=O)C3=C(C(=CC=C3)NC=O)O)C",
+                "compound": "splenocin C",
+                "database_id": [
+                    "pubchem:42626285"
+                ],
+                "mol_mass": "554.22643067",
+                "molecular_formula": "C29H34N2O9"
             }
         ],
         "loci": {

--- a/data/BGC0001268.json
+++ b/data/BGC0001268.json
@@ -27,7 +27,7 @@
         "compounds": [
             {
                 "chem_struct": "C/C=C(/C)\\C=C(/C)\\C=C(/C)\\C=C\\C=C(/C)\\C(=O)[C@@]12[C@@H](O1)[C@](NC2=O)(CCO)O",
-                "compound": "fusarin",
+                "compound": "fusarin C",
                 "database_id": [
                     "pubchem:15942871"
                 ],

--- a/data/BGC0001413.json
+++ b/data/BGC0001413.json
@@ -30,7 +30,7 @@
                 "database_id": [
                     "pubchem:122367906"
                 ],
-                "mol_mass": "919.30244913",
+                "mol_mass": 919.30244913,
                 "molecular_formula": "C46H45N7O14"
             },
             {
@@ -39,7 +39,7 @@
                 "database_id": [
                     "pubchem:122367908"
                 ],
-                "mol_mass": "919.30244913",
+                "mol_mass": 919.30244913,
                 "molecular_formula": "C46H45N7O14"
             },
             {

--- a/data/BGC0001413.json
+++ b/data/BGC0001413.json
@@ -25,7 +25,25 @@
         ],
         "compounds": [
             {
-                "compound": "cystobactamide"
+                "chem_struct": "CC(C)OC1=C(C=CC(=C1)C(=O)O)NC(=O)C2=C(C(=C(C=C2)NC(=O)C3=CC=C(C=C3)NC(=O)[C@H]([C@@H](C(=O)N)NC(=O)C4=CC=C(C=C4)NC(=O)C5=CC=C(C=C5)[N+](=O)[O-])OC)OC(C)C)O",
+                "compound": "cystobactamid 919-1",
+                "database_id": [
+                    "pubchem:122367906"
+                ],
+                "mol_mass": "919.30244913",
+                "molecular_formula": "C46H45N7O14"
+            },
+            {
+                "chem_struct": "CC(C)OC1=C(C=CC(=C1)C(=O)O)NC(=O)C2=C(C(=C(C=C2)NC(=O)C3=CC=C(C=C3)NC(=O)[C@H]([C@@H](C(=O)N)OC)NC(=O)C4=CC=C(C=C4)NC(=O)C5=CC=C(C=C5)[N+](=O)[O-])OC(C)C)O",
+                "compound": "cystobactamid 919-2",
+                "database_id": [
+                    "pubchem:122367908"
+                ],
+                "mol_mass": "919.30244913",
+                "molecular_formula": "C46H45N7O14"
+            },
+            {
+                "compound": "cystobactamid 919-3"
             }
         ],
         "loci": {

--- a/data/BGC0001465.json
+++ b/data/BGC0001465.json
@@ -26,7 +26,31 @@
         ],
         "compounds": [
             {
-                "compound": "bromopyrroles/bromophenols"
+                "chem_struct": "C1=C(C=C(C(=C1C2=C(C(=CC(=C2)Br)Br)O)O)Br)Br",
+                "compound": "bromophene",
+                "database_id": [
+                    "pubchem:30891"
+                ],
+                "mol_mass": "501.70603",
+                "molecular_formula": "C12H6Br4O2"
+            },
+            {
+                "chem_struct": "C1(=C(C(=C(N1)Br)Br)Br)C2=C(C(=C(N2)Br)Br)Br",
+                "compound": "bistribromopyrrole",
+                "database_id": [
+                    "pubchem:23426790"
+                ],
+                "mol_mass": "605.52568",
+                "molecular_formula": "C8H2Br6N2"
+            },
+            {
+                "chem_struct": "C1=C(C=C(C(=C1C2=C(C(=C(N2)Br)Br)Br)O)Br)Br",
+                "compound": "pentabromopseudilin",
+                "database_id": [
+                    "pubchem:324093"
+                ],
+                "mol_mass": "552.61688",
+                "molecular_formula": "C10H4Br5NO"
             }
         ],
         "loci": {
@@ -40,7 +64,7 @@
         "ncbi_tax_id": "717774",
         "organism_name": "Marinomonas mediterranea MMB-1",
         "publications": [
-            "doi:10.1038/nchembio.1564"
+            "pubmed:24974229"
         ]
     }
 }

--- a/data/BGC0001465.json
+++ b/data/BGC0001465.json
@@ -31,7 +31,7 @@
                 "database_id": [
                     "pubchem:30891"
                 ],
-                "mol_mass": "501.70603",
+                "mol_mass": 501.70603,
                 "molecular_formula": "C12H6Br4O2"
             },
             {
@@ -40,7 +40,7 @@
                 "database_id": [
                     "pubchem:23426790"
                 ],
-                "mol_mass": "605.52568",
+                "mol_mass": 605.52568,
                 "molecular_formula": "C8H2Br6N2"
             },
             {
@@ -49,7 +49,7 @@
                 "database_id": [
                     "pubchem:324093"
                 ],
-                "mol_mass": "552.61688",
+                "mol_mass": 552.61688,
                 "molecular_formula": "C10H4Br5NO"
             }
         ],

--- a/data/BGC0001526.json
+++ b/data/BGC0001526.json
@@ -25,25 +25,67 @@
         ],
         "compounds": [
             {
-                "compound": "bartolosides E"
+                "chem_struct": "CCCCCCC(CCCCCC1=C(C=C(C=C1O[C@H]2[C@@H]([C@H]([C@@H](CO2)O)O)O)CCCCCCC(CCCC)Cl)O)Cl",
+                "compound": "bartoloside E",
+                "database_id": [
+                    "pubchem:132582908"
+                ],
+                "mol_mass": "632.3610450",
+                "molecular_formula": "C34H58Cl2O6"
             },
             {
-                "compound": "bartolosides F"
+                "chem_struct": "CCCCCCCCC(CCCCCC1=CC(=C(C(=C1)O[C@H]2[C@@H]([C@H]([C@@H](CO2)O)O)O)CCCCCC(CCCCCC)Cl)O)Cl",
+                "compound": "bartoloside F",
+                "database_id": [
+                    "pubchem:132582909"
+                ],
+                "mol_mass": "674.4079951",
+                "molecular_formula": "C37H64Cl2O6"
             },
             {
-                "compound": "bartolosides G"
+                "chem_struct": "CCCCCCCCCCCCCC1=CC(=C(C(=C1)O[C@H]2[C@@H]([C@H]([C@@H](CO2)O)O)O)CCCCCC(CCCCCC)Cl)O",
+                "compound": "bartoloside G",
+                "database_id": [
+                    "pubchem:132582910"
+                ],
+                "mol_mass": "626.4313174",
+                "molecular_formula": "C36H63ClO6"
             },
             {
-                "compound": "bartolosides H"
+                "chem_struct": "CCCCCCCCCC(CCCCCC1=CC(=C(C(=C1)O[C@H]2[C@@H]([C@H]([C@@H](CO2)O)O)O)CCCCCC(CCCCCC)Cl)O)Cl",
+                "compound": "bartoloside H",
+                "database_id": [
+                    "pubchem:132582912"
+                ],
+                "mol_mass": "688.4236452",
+                "molecular_formula": "C38H66Cl2O6"
             },
             {
-                "compound": "bartolosides I"
+                "chem_struct": "CCCCCCCC(CCCCCC1=CC(=C(C(=C1)O[C@H]2[C@@H]([C@H]([C@@H](CO2)O)O)O)CCCCCC(CCCCCC)Cl)O)(Cl)Cl",
+                "compound": "bartoloside I",
+                "database_id": [
+                    "pubchem:132582914"
+                ],
+                "mol_mass": "694.353373",
+                "molecular_formula": "C36H61Cl3O6"
             },
             {
-                "compound": "bartolosides J"
+                "chem_struct": "CCCCCCCCCCCC1=CC(=C(C(=C1)O[C@H]2[C@@H]([C@H]([C@@H](CO2)O)O)O)CCCCCC(CCCCCC)Cl)O",
+                "compound": "bartoloside J",
+                "database_id": [
+                    "pubchem:132582915"
+                ],
+                "mol_mass": "598.4000173",
+                "molecular_formula": "C34H59ClO6"
             },
             {
-                "compound": "bartolosides K"
+                "chem_struct": "CCCCCCC(CCCCCC1=CC(=C(C(=C1)O[C@H]2[C@@H]([C@H]([C@@H](CO2)O)O)O)CCCCCC(CCCCCC)Cl)O)Cl",
+                "compound": "bartoloside K",
+                "database_id": [
+                    "pubchem:132582913"
+                ],
+                "mol_mass": "646.3766950",
+                "molecular_formula": "C35H60Cl2O6"
             }
         ],
         "loci": {

--- a/data/BGC0001526.json
+++ b/data/BGC0001526.json
@@ -30,7 +30,7 @@
                 "database_id": [
                     "pubchem:132582908"
                 ],
-                "mol_mass": "632.3610450",
+                "mol_mass": 632.3610450,
                 "molecular_formula": "C34H58Cl2O6"
             },
             {
@@ -39,7 +39,7 @@
                 "database_id": [
                     "pubchem:132582909"
                 ],
-                "mol_mass": "674.4079951",
+                "mol_mass": 674.4079951,
                 "molecular_formula": "C37H64Cl2O6"
             },
             {
@@ -48,7 +48,7 @@
                 "database_id": [
                     "pubchem:132582910"
                 ],
-                "mol_mass": "626.4313174",
+                "mol_mass": 626.4313174,
                 "molecular_formula": "C36H63ClO6"
             },
             {
@@ -57,7 +57,7 @@
                 "database_id": [
                     "pubchem:132582912"
                 ],
-                "mol_mass": "688.4236452",
+                "mol_mass": 688.4236452,
                 "molecular_formula": "C38H66Cl2O6"
             },
             {
@@ -66,7 +66,7 @@
                 "database_id": [
                     "pubchem:132582914"
                 ],
-                "mol_mass": "694.353373",
+                "mol_mass": 694.353373,
                 "molecular_formula": "C36H61Cl3O6"
             },
             {
@@ -75,7 +75,7 @@
                 "database_id": [
                     "pubchem:132582915"
                 ],
-                "mol_mass": "598.4000173",
+                "mol_mass": 598.4000173,
                 "molecular_formula": "C34H59ClO6"
             },
             {
@@ -84,7 +84,7 @@
                 "database_id": [
                     "pubchem:132582913"
                 ],
-                "mol_mass": "646.3766950",
+                "mol_mass": 646.3766950,
                 "molecular_formula": "C35H60Cl2O6"
             }
         ],

--- a/data/BGC0001620.json
+++ b/data/BGC0001620.json
@@ -25,7 +25,52 @@
         ],
         "compounds": [
             {
-                "compound": "ilamycins"
+                "chem_struct": "C/C=C/C[C@H]1C(=O)N[C@H](C(=O)N([C@H](C(=O)N[C@H](C(=O)N[C@H](C(=O)N([C@H](C(=O)N[C@H](C(=O)N1)CC(C)C)CC(C)C)C)C)CC2=CC(=C(C=C2)O)[N+](=O)[O-])CC(C)C)C)CC3=CN(C4=CC=CC=C43)C(C)(C)C=C",
+                "compound": "ilamycin B1",
+                "database_id": [
+                    "pubchem:101285944"
+                ],
+                "mol_mass": "1011.57933969",
+                "molecular_formula": "C54H77N9O10"
+            },
+            {
+                "chem_struct": "C/C=C/C[C@H]1C(=O)N[C@H](C(=O)N([C@H](C(=O)N[C@H](C(=O)N[C@H](C(=O)N([C@H](C(=O)N[C@H](C(=O)N1)CC(C)C)CC(C)C)C)C)CC2=CC(=C(C=C2)O)[N+](=O)[O-])CC(C)C)C)CC3=CN(C4=CC=CC=C43)C(C)(C)[C@H]5CO5",
+                "compound": "ilamycin B2",
+                "database_id": [
+                    "pubchem:156021420"
+                ],
+                "mol_mass": "1027.57425431",
+                "molecular_formula": "C54H77N9O11"
+            },
+            {
+                "chem_struct": "C/C=C/C[C@H]1C(=O)N[C@H](C(=O)N([C@H](C(=O)N[C@H](C(=O)N[C@H](C(=O)N([C@H]2C[C@@H]([C@H](N(C2=O)[C@H](C(=O)N1)CC(C)C)O)C)C)C)CC3=CC(=C(C=C3)O)[N+](=O)[O-])CC(C)C)C)CC4=CN(C5=CC=CC=C54)C(C)(C)[C@H]6CO6",
+                "compound": "ilamycin C1",
+                "database_id": [
+                    "pubchem:155524533"
+                ],
+                "mol_mass": "1041.55351886",
+                "molecular_formula": "C54H75N9O12"
+            },
+            {
+                "chem_struct": "C/C=C/C[C@H]1C(=O)N[C@H](C(=O)N([C@H](C(=O)N[C@H](C(=O)N[C@H](C(=O)N([C@H]2C[C@@H]([C@@H](N(C2=O)[C@H](C(=O)N1)CC(C)C)O)C)C)C)CC3=CC(=C(C=C3)O)[N+](=O)[O-])CC(C)C)C)CC4=CN(C5=CC=CC=C54)C(C)(C)[C@H]6CO6",
+                "compound": "ilamycin C2",
+                "database_id": [
+                    "pubchem:155545940"
+                ],
+                "mol_mass": "1041.55351886",
+                "molecular_formula": "C54H75N9O12"
+            },
+            {
+                "compound": "ilamycin D"
+            },
+            {
+                "chem_struct": "C/C=C/C[C@H]1C(=O)N[C@H](C(=O)N([C@H](C(=O)N[C@H](C(=O)N[C@H](C(=O)N([C@H]2C[C@@H]([C@H](N(C2=O)[C@H](C(=O)N1)CC(C)C)O)C)C)C)CC3=CC(=C(C=C3)O)[N+](=O)[O-])CC(C)C)C)CC4=CN(C5=CC=CC=C54)C(C)(C)C=C",
+                "compound": "ilamycin E1",
+                "database_id": [
+                    "pubchem:155560045"
+                ],
+                "mol_mass": "1025.55860424",
+                "molecular_formula": "C54H75N9O11"
             }
         ],
         "loci": {

--- a/data/BGC0001620.json
+++ b/data/BGC0001620.json
@@ -30,7 +30,7 @@
                 "database_id": [
                     "pubchem:101285944"
                 ],
-                "mol_mass": "1011.57933969",
+                "mol_mass": 1011.57933969,
                 "molecular_formula": "C54H77N9O10"
             },
             {
@@ -39,7 +39,7 @@
                 "database_id": [
                     "pubchem:156021420"
                 ],
-                "mol_mass": "1027.57425431",
+                "mol_mass": 1027.57425431,
                 "molecular_formula": "C54H77N9O11"
             },
             {
@@ -48,7 +48,7 @@
                 "database_id": [
                     "pubchem:155524533"
                 ],
-                "mol_mass": "1041.55351886",
+                "mol_mass": 1041.55351886,
                 "molecular_formula": "C54H75N9O12"
             },
             {
@@ -57,7 +57,7 @@
                 "database_id": [
                     "pubchem:155545940"
                 ],
-                "mol_mass": "1041.55351886",
+                "mol_mass": 1041.55351886,
                 "molecular_formula": "C54H75N9O12"
             },
             {
@@ -69,7 +69,7 @@
                 "database_id": [
                     "pubchem:155560045"
                 ],
-                "mol_mass": "1025.55860424",
+                "mol_mass": 1025.55860424,
                 "molecular_formula": "C54H75N9O11"
             }
         ],

--- a/data/BGC0001644.json
+++ b/data/BGC0001644.json
@@ -30,7 +30,7 @@
                 "database_id": [
                     "pubchem:139591548"
                 ],
-                "mol_mass": "970.69565780",
+                "mol_mass": 970.69565780,
                 "molecular_formula": "C54H98O14"
             },
             {
@@ -39,7 +39,7 @@
                 "database_id": [
                     "pubchem:139591549"
                 ],
-                "mol_mass": "956.68000773",
+                "mol_mass": 956.68000773,
                 "molecular_formula": "C53H96O14"
             }
         ],

--- a/data/BGC0001644.json
+++ b/data/BGC0001644.json
@@ -25,7 +25,22 @@
         ],
         "compounds": [
             {
-                "compound": "lacunalides"
+                "chem_struct": "C[C@@H]1[C@@H](C[C@H](C[C@@H](C[C@H](C[C@@H](C[C@H](CC=C(C=CC(=O)O[C@@H](CC=CCCCCCC[C@H](CCC[C@H](CCC[C@H](CC=C([C@H]1O)C)O)O)O)[C@@H](C)[C@@H](CCCCC[C@@H](C)O)O)C)O)O)O)O)O)O",
+                "compound": "lacunalide A",
+                "database_id": [
+                    "pubchem:139591548"
+                ],
+                "mol_mass": "970.69565780",
+                "molecular_formula": "C54H98O14"
+            },
+            {
+                "chem_struct": "C[C@@H]1[C@@H](C[C@H](C[C@@H](C[C@H](C[C@@H](C[C@H](CC=C(C=CC(=O)O[C@@H](CC=CCCCCCC[C@H](CCC[C@H](CCC[C@H](CC=C[C@H]1O)O)O)O)[C@@H](C)[C@@H](CCCCC[C@@H](C)O)O)C)O)O)O)O)O)O",
+                "compound": "lacunalide B",
+                "database_id": [
+                    "pubchem:139591549"
+                ],
+                "mol_mass": "956.68000773",
+                "molecular_formula": "C53H96O14"
             }
         ],
         "loci": {

--- a/data/BGC0001716.json
+++ b/data/BGC0001716.json
@@ -30,7 +30,7 @@
                 "database_id": [
                     "pubchem:146684503"
                 ],
-                "mol_mass": "1295.78983499",
+                "mol_mass": 1295.78983499,
                 "molecular_formula": "C54H101N23O14"
             },
             {
@@ -39,7 +39,7 @@
                 "database_id": [
                     "pubchem:146684504"
                 ],
-                "mol_mass": "1279.79492037",
+                "mol_mass": 1279.79492037,
                 "molecular_formula": "C54H101N23O13"
             },
             {
@@ -48,7 +48,7 @@
                 "database_id": [
                     "pubchem:132031638"
                 ],
-                "mol_mass": "1263.80000575",
+                "mol_mass": 1263.80000575,
                 "molecular_formula": "C54H101N23O12"
             }
         ],

--- a/data/BGC0001716.json
+++ b/data/BGC0001716.json
@@ -25,7 +25,31 @@
         ],
         "compounds": [
             {
-                "compound": "odilorhabdins"
+                "chem_struct": "C1C[C@H](N(C1)C(=O)[C@@H](CCCN)NC(=O)CNC(=O)[C@H]([C@H](CN)O)NC(=O)[C@H]([C@H](CN)O)NC(=O)[C@H](CCCCN)N)C(=O)N[C@@H](CC2=CN=CN2)C(=O)N[C@@H](CC[C@@H](CN)O)C(=O)N/C(=C\\CCN=C(N)N)/C(=O)N[C@@H](CC[C@@H](CN)O)C(=O)NCCCCN",
+                "compound": "odilorhabdin NOSO-95A",
+                "database_id": [
+                    "pubchem:146684503"
+                ],
+                "mol_mass": "1295.78983499",
+                "molecular_formula": "C54H101N23O14"
+            },
+            {
+                "chem_struct": "C1C[C@H](N(C1)C(=O)[C@@H](CCCN)NC(=O)CNC(=O)[C@H]([C@H](CN)O)NC(=O)[C@H]([C@H](CN)O)NC(=O)[C@H](CCCCN)N)C(=O)N[C@@H](CC2=CN=CN2)C(=O)N[C@@H](CC[C@@H](CN)O)C(=O)N/C(=C\\CCN=C(N)N)/C(=O)N[C@@H](CCCCN)C(=O)NCCCCN",
+                "compound": "odilorhabdin NOSO-95B",
+                "database_id": [
+                    "pubchem:146684504"
+                ],
+                "mol_mass": "1279.79492037",
+                "molecular_formula": "C54H101N23O13"
+            },
+            {
+                "chem_struct": "C1C[C@H](N(C1)C(=O)[C@@H](CCCN)NC(=O)CNC(=O)[C@H]([C@H](CN)O)NC(=O)[C@H]([C@H](CN)O)NC(=O)[C@H](CCCCN)N)C(=O)N[C@@H](CC2=CN=CN2)C(=O)N[C@@H](CCCCN)C(=O)N/C(=C\\CCN=C(N)N)/C(=O)N[C@@H](CCCCN)C(=O)NCCCCN",
+                "compound": "odilorhabdin NOSO-95C",
+                "database_id": [
+                    "pubchem:132031638"
+                ],
+                "mol_mass": "1263.80000575",
+                "molecular_formula": "C54H101N23O12"
             }
         ],
         "loci": {

--- a/data/BGC0001983.json
+++ b/data/BGC0001983.json
@@ -21,7 +21,7 @@
                 "database_id": [
                     "pubchem:9576787"
                 ],
-                "mol_mass": "207.137162174",
+                "mol_mass": 207.137162174,
                 "molecular_formula": "C11H17N3O"
             }
         ],

--- a/data/BGC0001983.json
+++ b/data/BGC0001983.json
@@ -16,7 +16,13 @@
         ],
         "compounds": [
             {
-                "compound": "triacsins"
+                "chem_struct": "CCC/C=C/C/C=C/C=C/C=N/NN=O",
+                "compound": "triacsin C",
+                "database_id": [
+                    "pubchem:9576787"
+                ],
+                "mol_mass": "207.137162174",
+                "molecular_formula": "C11H17N3O"
             }
         ],
         "loci": {

--- a/data/BGC0002019.json
+++ b/data/BGC0002019.json
@@ -16,7 +16,76 @@
         ],
         "compounds": [
             {
-                "compound": "tiancilactone"
+                "chem_struct": "C[C@@H]1[C@H](C[C@@H]2[C@]3(CC[C@@H]([C@@]([C@@H]3CC[C@@]2([C@H]1C4=C(C(=O)OC4O)O)C)(C)COC(=O)C5=C(C=CC(=C5)Cl)NC)O)C)OC",
+                "compound": "tiancilactone A",
+                "database_id": [
+                    "pubchem:156582164"
+                ],
+                "mol_mass": "605.2755451",
+                "molecular_formula": "C32H44ClNO8"
+            },
+            {
+                "chem_struct": "C[C@@H]1[C@H](C[C@@H]2[C@]3(CC[C@@H]([C@@]([C@@H]3CC[C@@]2([C@H]1C4=C(C(=O)OC4O)O)C)(C)COC(=O)C5=CC=CC=C5NC)O)C)OC",
+                "compound": "tiancilactone B",
+                "database_id": [
+                    "pubchem:156582165"
+                ],
+                "mol_mass": "571.31451739",
+                "molecular_formula": "C32H45NO8"
+            },
+            {
+                "chem_struct": "C[C@@H]1[C@H](C[C@@H]2[C@]3(CC[C@@H]([C@@]([C@@H]3CC[C@@]2([C@H]1C4=C(C(=O)OC4O)O)C)(C)CO)OC(=O)C5=C(C=CC(=C5)Cl)NC)C)OC",
+                "compound": "tiancilactone C",
+                "database_id": [
+                    "pubchem:156582166"
+                ],
+                "mol_mass": "605.2755451",
+                "molecular_formula": "C32H44ClNO8"
+            },
+            {
+                "chem_struct": "C[C@@H]1[C@H](C[C@@H]2[C@]3(CC[C@@H]([C@@]([C@@H]3CC[C@@]2([C@H]1C4=C(C(=O)O[C@H]4NCCO)O)C)(C)COC(=O)C5=C(C=CC(=C5)Cl)NC)O)C)OC",
+                "compound": "tiancilactone D",
+                "database_id": [
+                    "pubchem:156582167"
+                ],
+                "mol_mass": "648.3177442",
+                "molecular_formula": "C34H49ClN2O8"
+            },
+            {
+                "chem_struct": "C[C@@H]1[C@H](C[C@@H]2[C@]3(CC[C@@H]([C@@]([C@@H]3CC[C@@]2([C@H]1C4=C(C(=O)O[C@H]4N(C)CCO)O)C)(C)COC(=O)C5=C(C=CC(=C5)Cl)NC)O)C)OC",
+                "compound": "tiancilactone E",
+                "database_id": [
+                    "pubchem:156582168"
+                ],
+                "mol_mass": "662.3333943",
+                "molecular_formula": "C35H51ClN2O8"
+            },
+            {
+                "chem_struct": "C[C@@H]1[C@H](C[C@@H]2[C@]3(CC[C@@H]([C@@]([C@@H]3CC[C@@]2([C@H]1/C(=C/O)/C=O)C)(C)COC(=O)C4=C(C=CC(=C4)Cl)NC)O)C)OC",
+                "compound": "tiancilactone F",
+                "database_id": [
+                    "pubchem:156582169"
+                ],
+                "mol_mass": "561.2857158",
+                "molecular_formula": "C31H44ClNO6"
+            },
+            {
+                "chem_struct": "C[C@@H]1[C@H](C[C@@H]2[C@]3(CC[C@@H]([C@@]([C@@H]3CC[C@@]2([C@H]1CCO)C)(C)COC(=O)C4=C(C=CC(=C4)Cl)NC)O)C)OC",
+                "compound": "tiancilactone G",
+                "database_id": [
+                    "pubchem:156582170"
+                ],
+                "mol_mass": "535.3064513",
+                "molecular_formula": "C30H46ClNO5"
+            },
+            {
+                "chem_struct": "CC1=C[C@@H]2[C@@H]3[C@]4(CC[C@@H](C([C@@H]4CC[C@@]3([C@H]1[C@@H](O2)CC(=O)O)C)(C)C)O)C",
+                "compound": "tiancilactone H",
+                "database_id": [
+                    "pubchem:156582171"
+                ],
+                "mol_mass": "362.24570956",
+                "molecular_formula": "C22H34O4"
             }
         ],
         "loci": {

--- a/data/BGC0002019.json
+++ b/data/BGC0002019.json
@@ -21,7 +21,7 @@
                 "database_id": [
                     "pubchem:156582164"
                 ],
-                "mol_mass": "605.2755451",
+                "mol_mass": 605.2755451,
                 "molecular_formula": "C32H44ClNO8"
             },
             {
@@ -30,7 +30,7 @@
                 "database_id": [
                     "pubchem:156582165"
                 ],
-                "mol_mass": "571.31451739",
+                "mol_mass": 571.31451739,
                 "molecular_formula": "C32H45NO8"
             },
             {
@@ -39,7 +39,7 @@
                 "database_id": [
                     "pubchem:156582166"
                 ],
-                "mol_mass": "605.2755451",
+                "mol_mass": 605.2755451,
                 "molecular_formula": "C32H44ClNO8"
             },
             {
@@ -48,7 +48,7 @@
                 "database_id": [
                     "pubchem:156582167"
                 ],
-                "mol_mass": "648.3177442",
+                "mol_mass": 648.3177442,
                 "molecular_formula": "C34H49ClN2O8"
             },
             {
@@ -57,7 +57,7 @@
                 "database_id": [
                     "pubchem:156582168"
                 ],
-                "mol_mass": "662.3333943",
+                "mol_mass": 662.3333943,
                 "molecular_formula": "C35H51ClN2O8"
             },
             {
@@ -66,7 +66,7 @@
                 "database_id": [
                     "pubchem:156582169"
                 ],
-                "mol_mass": "561.2857158",
+                "mol_mass": 561.2857158,
                 "molecular_formula": "C31H44ClNO6"
             },
             {
@@ -75,7 +75,7 @@
                 "database_id": [
                     "pubchem:156582170"
                 ],
-                "mol_mass": "535.3064513",
+                "mol_mass": 535.3064513,
                 "molecular_formula": "C30H46ClNO5"
             },
             {
@@ -84,7 +84,7 @@
                 "database_id": [
                     "pubchem:156582171"
                 ],
-                "mol_mass": "362.24570956",
+                "mol_mass": 362.24570956,
                 "molecular_formula": "C22H34O4"
             }
         ],

--- a/data/BGC0002021.json
+++ b/data/BGC0002021.json
@@ -21,7 +21,7 @@
                 "database_id": [
                     "pubchem:11493248"
                 ],
-                "mol_mass": "306.11033829",
+                "mol_mass": 306.11033829,
                 "molecular_formula": "C16H18O6"
             },
             {

--- a/data/BGC0002021.json
+++ b/data/BGC0002021.json
@@ -16,7 +16,13 @@
         ],
         "compounds": [
             {
-                "compound": "fogacin A"
+                "chem_struct": "C[C@H]1C2=C(C3=C(C=C2C[C@@H](O1)CC(=O)O)C(CCC3=O)O)O",
+                "compound": "fogacin",
+                "database_id": [
+                    "pubchem:11493248"
+                ],
+                "mol_mass": "306.11033829",
+                "molecular_formula": "C16H18O6"
             },
             {
                 "compound": "fogacin B"


### PR DESCRIPTION
Hi ! 

This PR fixes some annotations for the chemical products synthesized by several BGCs. I added cross-references to PubChem and extracted additional metadata from there when it was possible.

## BGC0000231

`BGC0000231` does not produce a single molecule named `griseusin`, but two related compounds named `griseusin A` and `griseusin B`, as described in [PMID:8169211](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC205401/?page=2)

![image](https://user-images.githubusercontent.com/8660647/175036458-92e1ec2e-e84b-4741-b63d-8a63212272c4.png)


## BGC0000243 and BGC0000244

These BGCs were reported produce several molecules of the `macrotetrolide` family, but they were not detailed. I added the metadata for the 5 macrotetrolides produced naturally and described in [PMID:10858335](https://pubmed.ncbi.nlm.nih.gov/10858335/) (the reference paper).

![image](https://user-images.githubusercontent.com/8660647/175036545-ee567aeb-44f1-4d9f-b699-1914e8265f9e.png)


## BGC0000248

`BGC0000248` was reported to produce `naphtocyclinone`, but the authors name it `α-naphthocyclinone` in the manuscript, and since then additional naphthocyclinones have been isolated (`δ-naphtocyclinone`, etc.)

![image](https://user-images.githubusercontent.com/8660647/175036694-4c6dad0d-2fcb-4ded-8bea-40cbf0a271a9.png)


## BGC0000402

This BGC listed its product as `paenilarvins`, but in the reference manuscript authors have characterized three different molecules: `paenilarvin A`, `paenilarvin B` and `paenilarvin C`.

![image](https://user-images.githubusercontent.com/8660647/175036788-ae7bb174-cbfb-4529-96b5-ba3c88a8e400.png)


## BGC0000662

This BGC listed its product as `grixazone`, but is actually `grixazone A` in PubChem. I also added a new reference for this cluster ([PMID:17617696](https://pubmed.ncbi.nlm.nih.gov/17617696/)) which describes the biosynthetic pathway of `grixazone A` based on this cluster.

![image](https://user-images.githubusercontent.com/8660647/175036889-575cdd24-5a4f-4d3d-b44e-420ec5e06bb8.png)

## BGC0001167

This BGC listed `piricyclamide` as its product but it actually produces 4 different compounds according to [PMID:22952627](https://pubmed.ncbi.nlm.nih.gov/22952627). 

![image](https://user-images.githubusercontent.com/8660647/175036972-ac939601-6db6-498e-af0d-ed34162519cf.png)

## BGC0001268

According to the reference paper ([PMID:23932525](https://pubmed.ncbi.nlm.nih.gov/23932525)), the end product of the biosynthetic pathway encoded in this BGC is `fusarin C`.

![image](https://user-images.githubusercontent.com/8660647/175037158-e1625ae7-c373-4e73-8fcd-f5899e296d27.png)


## BGC0001413

According to the reference paper ([PMID:25510965](https://pubmed.ncbi.nlm.nih.gov/25510965)), this BGC produces 3 `cystobactamid` products.

![image](https://user-images.githubusercontent.com/8660647/175036269-b2a374f5-916b-4e5b-a66b-1bf67ff1af9b.png)


## BGC0001465

The BGC product was listed as generic *bromopyrroles/bromophenols*, but the reference paper ([PMID:24974229](https://pubmed.ncbi.nlm.nih.gov/24974229)) gave a structure for the three naturally-occuring compounds without naming them explicitly.

![image](https://user-images.githubusercontent.com/8660647/175036120-e16ec87e-871e-48d4-aeaf-2a29de69a9a7.png)

I manually searched for these molecules based on the molecule structure in PubChem to get the corresponding compounds: `bromophene`, `pentabromopseudilin` and `bistribromopyrrole`.

## BGC0001526

I fixed the name of the compounds (`bartolosides A` -> `bartoloside A`, etc.) and added cross-references to PubChem.

## BGC0001620

According to the reference paper ([PMID:28855504](https://pubmed.ncbi.nlm.nih.gov/28855504)), this BGC leads to the production of 6 naturally occuring compounds (`ilamycin E2` and `ilamycin F` were obtained by cluster engineering).

![image](https://user-images.githubusercontent.com/8660647/175037528-8e393ee0-056b-4005-8c6b-84e7bee56cc7.png)

## BGC0001644

According to the reference paper ([PMID:30025185](https://pubmed.ncbi.nlm.nih.gov/30025185)), this BGC produces two related compounds, `lacunalide A` and its desmethyl derivative `lacunalide B`:

![image](https://user-images.githubusercontent.com/8660647/175038200-30fd4708-f81e-4907-b9fe-30667e99058c.png)

## BGC0001716

I added the compounds from [PMID:29625040](https://pubmed.ncbi.nlm.nih.gov/29625040). It's a bit unclear how they should be named, in the article they are called `odilorhabdin NOSO-95A` or `NOSO-95A` with no consistency. In the end I used the longer name from PubChem. 

![image](https://user-images.githubusercontent.com/8660647/175039380-561423e3-bb85-49bb-b994-abed31d14d45.png)


## BGC0001983

The paper reports 4 different `triacsin` compounds, but only `triacsin C` (refered as compound 3) was found:

> UV traces (300 nm) confirming the production of 3 in S. tsukubaensis. In both strains, the congener 3 was produced as the major product and other congeners were not identifiable by UV in these traces.

![nihms-1036726-f0002](https://user-images.githubusercontent.com/8660647/175040081-588baac2-8627-4659-9a9e-22b9b39fc9a0.jpg)

## BGC0002019

The reference paper ([PMID:29806086](https://pubmed.ncbi.nlm.nih.gov/29806086)) describes 11 `tiancilactone` molecules:

![image](https://user-images.githubusercontent.com/8660647/175040832-42b64971-e424-43d5-9859-681a2848910d.png)

However, based on the metabolite profile of the strain fermentation extract, only 8 of them are being produced by _Streptomyces sp. CB03234_, so I only added these 8 compounds to the BGC products.

## BGC0002021

Rename `fogacin A` to `fogacin`, which is named as such in PubChem and in the reference paper ([PMID:30556239](https://pubmed.ncbi.nlm.nih.gov/30556239/)), despite the derivatives being called `fogacin B` and `fogacin C`.

## BGC0001216

The reference paper ([PMID:25763681](https://pubmed.ncbi.nlm.nih.gov/25763681)) describes 4 different `splenocin` molecules, but in the manuscript text the authors say they only observe production of `splenocin C`: 

> In our hands, we only observe SPN-C in the fermentation of CNQ431 [...]



