### PR TITLE
BGC0000984: fix bad location change

### DIFF
--- a/data/BGC0000984.json
+++ b/data/BGC0000984.json
@@ -59,8 +59,8 @@
         "loci": {
             "accession": "CP000884.1",
             "completeness": "Unknown",
-            "end_coord": 5200652,
-            "start_coord": 526767
+            "end_coord": 5260767,
+            "start_coord": 5200652
         },
         "mibig_accession": "BGC0000984",
         "minimal": true,


### PR DESCRIPTION
I somehow completely butchered the location for BGC0000984 in f9918b5f10564f275b8f062676612c86a7f39434, this corrects that location.

No change to the changelog was made, since it's the same change message as previous, but done correctly this time .