### PR TITLE
BGC0000101: retire as multi-contig

### DIFF
--- a/retired/BGC0000101.json
+++ b/retired/BGC0000101.json
@@ -23,8 +23,8 @@
             "comments": [
                 "Removed ketoreductase stereochemistry annotation from modules without ketoreductases",
                 "Corrected loci",
-                "Removed gene from different contig",
-                "Removed thioesterase with unknown gene ID"
+                "Removed thioesterase with unknown gene ID",
+                "Retired due to involving multiple contigs"
             ],
             "contributors": [
                 "AAAAAAAAAAAAAAAAAAAAAAAA"
@@ -89,6 +89,26 @@
                 "molecular_formula": "C25H26O5"
             }
         ],
+        "genes": {
+            "annotations": [
+                {
+                    "functions": [
+                        {
+                            "category": "Tailoring",
+                            "evidence": [
+                                "Knock-out"
+                            ]
+                        }
+                    ],
+                    "id": "CBF73676.1",
+                    "name": "xptC",
+                    "product": "oxidoreductase",
+                    "tailoring": [
+                        "Oxidation"
+                    ]
+                }
+            ]
+        },
         "loci": {
             "accession": "BN001308.1",
             "completeness": "complete",


### PR DESCRIPTION
This should have been retired the last time I modified it to remove completely missing genes. This also returns the gene annotation missed for xptC which is required for the compound(s) since it's directly related to the retirement.