### PR TITLE
Updated MIBiG jsonschema.

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "$schema_created": "2022-08-18T19:36:44+02:00",
-    "$schema_version": "2.11",
+    "$schema_version": "2.14",
     "additionalProperties": false,
     "properties": {
         "changelog": {
@@ -19,6 +19,13 @@
                             "type": "string"
                         },
                         "type": "array"
+                    },
+                    "updated_at": {
+                        "items": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "type":"array"
                     },
                     "version": {
                         "pattern": "^(\\d+(\\.\\d+)*|next)$",
@@ -533,6 +540,8 @@
                         "evidence": {
                             "items": {
                                 "enum": [
+                                    "Homology-based prediction",
+                                    "Correlation of genomic and metabolomic data",
                                     "Gene expression correlated with compound production",
                                     "Knock-out studies",
                                     "Enzymatic assays",
@@ -1362,6 +1371,8 @@
                         "anthelmintic",
                         "antialgal",
                         "antibacterial",
+                        "antibacterial (Gram-negative)",
+                        "antibacterial (Gram-positive)",
                         "anticancer",
                         "anticoccidial",
                         "antifungal",


### PR DESCRIPTION
Dear all, 

proposed is an update to the MIBiG JSON schema. All changes have been discussed and approved by Kai and/or Marnix.

Changes:
- Changelog: intoduced an optional `updated_at` field which allows to keep track of when which change was performed.
- Loci: introduced additional evidence classes which have been so far considered implicit.
- Defs: added two activity lables to specify antibiotic activity in more detail.

Tests:
- The schema is backward-compatible: older entries validate against it.

Kind regards, 

Mitja